### PR TITLE
Enable support for the underscore character in POP3 usernames/addresses

### DIFF
--- a/src/Pop3Server/Protocol/SmtpParser.cs
+++ b/src/Pop3Server/Protocol/SmtpParser.cs
@@ -2171,6 +2171,7 @@ namespace Pop3Server.Protocol
             case TokenKind.Number:
             case TokenKind.Space:
             case TokenKind.Hyphen:
+            case TokenKind.Underscore:
             case TokenKind.Period:
             case TokenKind.LeftBracket:
             case TokenKind.RightBracket:

--- a/src/Pop3Server/Text/TokenKind.cs
+++ b/src/Pop3Server/Text/TokenKind.cs
@@ -26,7 +26,12 @@ namespace Pop3Server.Text
         /// -
         /// </summary>
         Hyphen,
-        
+
+        /// <summary>
+        /// _
+        /// </summary>
+        Underscore,
+
         /// <summary>
         /// .
         /// </summary>
@@ -55,7 +60,7 @@ namespace Pop3Server.Text
         /// <summary>
         /// <
         /// </summary>
-        LessThan = 10,
+        LessThan,
 
         /// <summary>
         /// ,

--- a/src/Pop3Server/Text/TokenReader.cs
+++ b/src/Pop3Server/Text/TokenReader.cs
@@ -62,7 +62,7 @@ namespace Pop3Server.Text
             _peek = default;
             _hasPeeked = false;
         }
-        
+
         /// <summary>
         /// Create a checkpoint of the current state.
         /// </summary>
@@ -266,6 +266,9 @@ namespace Pop3Server.Text
 
                 case { } ch when ch == '-':
                     return new Token(TokenKind.Hyphen, ReadOne());
+
+                case { } ch when ch == '_':
+                    return new Token(TokenKind.Underscore, ReadOne());
 
                 case { } ch when ch == '.':
                     return new Token(TokenKind.Period, ReadOne());


### PR DESCRIPTION
Resolved issue where POP3 usernames containing an underscore character (_) were incorrectly truncated at the underscore.
For example, "myuser_1@somewhere.com" was previously interpreted as "myuser".
This patch adds proper support for underscore characters in POP3 usernames, ensuring full address recognition.