### PR TITLE
 Add `TopCommand` and enhance `RetrCommand` with tests

### DIFF
--- a/example/Pop3WorkerService/Pop3WorkerService.csproj
+++ b/example/Pop3WorkerService/Pop3WorkerService.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pop3server.sln
+++ b/pop3server.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pop3Server.Hosting", "src\P
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pop3WorkerService", "example\Pop3WorkerService\Pop3WorkerService.csproj", "{C9396ED5-8C25-413B-8B29-9FB65F0CBC4B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pop3Server.Test", "src\Pop3Server.Test\Pop3Server.Test.csproj", "{AFE421B8-5D33-0ED7-22C7-C7B97A465E80}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{C9396ED5-8C25-413B-8B29-9FB65F0CBC4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9396ED5-8C25-413B-8B29-9FB65F0CBC4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9396ED5-8C25-413B-8B29-9FB65F0CBC4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFE421B8-5D33-0ED7-22C7-C7B97A465E80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFE421B8-5D33-0ED7-22C7-C7B97A465E80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFE421B8-5D33-0ED7-22C7-C7B97A465E80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFE421B8-5D33-0ED7-22C7-C7B97A465E80}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Pop3Server.Hosting/Pop3Server.Hosting.csproj
+++ b/src/Pop3Server.Hosting/Pop3Server.Hosting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pop3Server.Test/Helpers/TestEndpointDefinition.cs
+++ b/src/Pop3Server.Test/Helpers/TestEndpointDefinition.cs
@@ -1,0 +1,16 @@
+namespace Pop3Server.Test.Helpers
+{
+  public class TestEndpointDefinition : IEndpointDefinition
+  {
+    public System.Net.IPEndPoint Endpoint => new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 110);
+    public bool IsSecure => false;
+    public bool AuthenticationRequired => true;
+    public bool AllowUnsecureAuthentication => true;
+    public TimeSpan ReadTimeout => TimeSpan.FromMinutes(1);
+
+    public System.Security.Authentication.SslProtocols SupportedSslProtocols =>
+        System.Security.Authentication.SslProtocols.Tls12;
+
+    ICertificateFactory IEndpointDefinition.CertificateFactory => null;
+  }
+}

--- a/src/Pop3Server.Test/Helpers/TestMessageStore.cs
+++ b/src/Pop3Server.Test/Helpers/TestMessageStore.cs
@@ -1,0 +1,44 @@
+using Pop3Server.Mail;
+using Pop3Server.Storage;
+
+namespace Pop3Server.Test.Helpers
+{
+  public class TestMessageStore : IMessageStore
+  {
+    private readonly Dictionary<IPop3Message, byte[]> _messages = new Dictionary<IPop3Message, byte[]>();
+
+    public void AddMessage(IPop3Message message, byte[] content)
+    {
+      _messages[message] = content;
+    }
+
+    public Task<byte[]> GetAsync(ISessionContext context, IMailbox mailbox, IPop3Message message, CancellationToken cancellationToken)
+    {
+      if (_messages.TryGetValue(message, out var content))
+      {
+        return Task.FromResult(content);
+      }
+      return Task.FromResult(new byte[0]);
+    }
+
+    public Task<IPop3Message[]> GetMessagesAsync(ISessionContext context, IMailbox mailbox, CancellationToken cancellationToken)
+    {
+      return Task.FromResult(Array.Empty<IPop3Message>());
+    }
+
+    public Task DeleteAsync(ISessionContext context, IMailbox mailbox, IPop3Message[] messages, CancellationToken cancellationToken)
+    {
+      return Task.CompletedTask;
+    }
+
+    public Task<bool> LockMailboxAsync(ISessionContext context, IMailbox mailbox, CancellationToken cancellationToken)
+    {
+      return Task.FromResult(true);
+    }
+
+    public Task UnlockMailboxAsync(ISessionContext context, IMailbox mailbox, CancellationToken cancellationToken)
+    {
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Pop3Server.Test/Helpers/TestMessageStoreFactory.cs
+++ b/src/Pop3Server.Test/Helpers/TestMessageStoreFactory.cs
@@ -1,0 +1,19 @@
+using Pop3Server.Storage;
+
+namespace Pop3Server.Test.Helpers
+{
+  public class TestMessageStoreFactory : IMessageStoreFactory
+  {
+    private readonly IMessageStore _messageStore;
+
+    public TestMessageStoreFactory(IMessageStore messageStore)
+    {
+      _messageStore = messageStore;
+    }
+
+    public IMessageStore CreateInstance(ISessionContext context)
+    {
+      return _messageStore;
+    }
+  }
+}

--- a/src/Pop3Server.Test/Helpers/TestPop3Message.cs
+++ b/src/Pop3Server.Test/Helpers/TestPop3Message.cs
@@ -1,0 +1,9 @@
+namespace Pop3Server.Test.Helpers
+{
+  public class TestPop3Message : IPop3Message
+  {
+    public string Id { get; set; }
+    public int Size { get; set; }
+    public bool DeleteRequested { get; set; }
+  }
+}

--- a/src/Pop3Server.Test/Helpers/TestPop3ServerOptions.cs
+++ b/src/Pop3Server.Test/Helpers/TestPop3ServerOptions.cs
@@ -1,0 +1,16 @@
+namespace Pop3Server.Test.Helpers
+{
+  public class TestPop3ServerOptions : IPop3ServerOptions
+  {
+    public int MaxMessageSize => 10000000;
+    public int MaxRetryCount => 3;
+    public int MaxAuthenticationAttempts => 3;
+    public string ServerName => "test.server";
+
+    public IReadOnlyList<IEndpointDefinition> Endpoints =>
+        new List<IEndpointDefinition>();
+
+    public TimeSpan CommandWaitTimeout => TimeSpan.FromMinutes(1);
+    public int NetworkBufferSize => 4096;
+  }
+}

--- a/src/Pop3Server.Test/Helpers/TestSecurableDuplexPipe.cs
+++ b/src/Pop3Server.Test/Helpers/TestSecurableDuplexPipe.cs
@@ -1,0 +1,27 @@
+using Pop3Server.IO;
+using System.IO.Pipelines;
+
+namespace Pop3Server.Test.Helpers
+{
+  public class TestSecurableDuplexPipe : ISecurableDuplexPipe
+  {
+    public TestSecurableDuplexPipe(PipeReader reader, PipeWriter writer)
+    {
+      Input = reader;
+      Output = writer;
+    }
+
+    public PipeReader Input { get; }
+    public PipeWriter Output { get; }
+    public bool IsSecure => false;
+
+    public Task UpgradeAsync(System.Security.Cryptography.X509Certificates.X509Certificate certificate,
+        System.Security.Authentication.SslProtocols protocols, CancellationToken cancellationToken = default)
+    {
+      throw new NotImplementedException();
+    }
+
+    public void Dispose()
+    { }
+  }
+}

--- a/src/Pop3Server.Test/Helpers/TestServiceProvider.cs
+++ b/src/Pop3Server.Test/Helpers/TestServiceProvider.cs
@@ -1,0 +1,23 @@
+using Pop3Server.Storage;
+
+namespace Pop3Server.Test.Helpers
+{
+  public class TestServiceProvider : IServiceProvider
+  {
+    private readonly IMessageStore _messageStore;
+
+    public TestServiceProvider(IMessageStore messageStore = null)
+    {
+      _messageStore = messageStore ?? new TestMessageStore();
+    }
+
+    public object GetService(Type serviceType)
+    {
+      if (serviceType == typeof(IMessageStoreFactory))
+      {
+        return new TestMessageStoreFactory(_messageStore);
+      }
+      return null;
+    }
+  }
+}

--- a/src/Pop3Server.Test/Pop3Server.Test.csproj
+++ b/src/Pop3Server.Test/Pop3Server.Test.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pop3Server\Pop3Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Pop3Server.Test/RetrCommandTests.cs
+++ b/src/Pop3Server.Test/RetrCommandTests.cs
@@ -1,0 +1,429 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using Pop3Server.Mail;
+using Pop3Server.Protocol;
+using Pop3Server.Storage;
+using Pop3Server.Test.Helpers;
+
+namespace Pop3Server.Test
+{
+  public partial class RetrCommandTests
+  {
+    private SmtpSessionContext CreateContext(IMessageStore messageStore = null)
+    {
+      var pipe = new Pipe();
+      var serviceProvider = new TestServiceProvider(messageStore ?? new TestMessageStore());
+      var options = new TestPop3ServerOptions();
+      var endpointDefinition = new TestEndpointDefinition();
+
+      var context = new SmtpSessionContext(serviceProvider, options, endpointDefinition)
+      {
+        Pipe = new TestSecurableDuplexPipe(pipe.Reader, pipe.Writer)
+      };
+
+      return context;
+    }
+
+    private byte[] CreateTestMessage(string headers, string body)
+    {
+      var message = $"""
+                {headers}
+
+                {body}
+                """;
+      return Encoding.ASCII.GetBytes(message);
+    }
+
+    #region ExecuteAsync Tests
+
+    [Fact]
+    public async Task ExecuteAsync_ValidMessage_ReturnsOkResponse()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageContent = CreateTestMessage("Subject: Test", "Body content");
+      var messageStore = new TestMessageStore();
+      messageStore.AddMessage(testMessage, messageContent);
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(1);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = $"""
+        +OK message follows {messageContent.Length} octets
+        Subject: Test
+
+        Body content
+        .
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidMessage_ReturnsCorrectSize()
+    {
+      // Arrange
+      var testContent = CreateTestMessage("Subject: Test", "Body content");
+      var testMessage = new TestPop3Message { Id = "1", Size = testContent.Length, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      messageStore.AddMessage(testMessage, testContent);
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(1);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = $"""
+        +OK message follows {testContent.Length} octets
+        Subject: Test
+
+        Body content
+        .
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MessageNumberLessThanOne_ReturnsError()
+    {
+      // Arrange
+      var context = CreateContext();
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+
+      var command = new RetrCommand(0);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.False(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = """
+        -ERR no such message
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MessageNumberGreaterThanCount_ReturnsError()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var context = CreateContext();
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(5); // Request message 5 when only 1 exists
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.False(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = """
+        -ERR no such message
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeletedMessage_ReturnsError()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = true };
+      var context = CreateContext();
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(1);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.False(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = """
+        -ERR no such message
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MessageWithDotAtLineStart_ReturnsDotStuffed()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      var messageContent = CreateTestMessage(
+          "Subject: Test",
+          """
+          Line 1
+          .This line starts with a dot
+          Line 3
+          """);
+      messageStore.AddMessage(testMessage, messageContent);
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(1);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = $"""
+        +OK message follows {messageContent.Length} octets
+        Subject: Test
+
+        Line 1
+        ..This line starts with a dot
+        Line 3
+        .
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MessageWithMultipleDotLines_ReturnsAllDotStuffed()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      var messageContent = CreateTestMessage(
+          "Subject: Test",
+          """
+          .First dot line
+          Normal line
+          .Second dot line
+          .Third dot line
+          """);
+      messageStore.AddMessage(testMessage, messageContent);
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(1);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = $"""
+        +OK message follows {messageContent.Length} octets
+        Subject: Test
+
+        ..First dot line
+        Normal line
+        ..Second dot line
+        ..Third dot line
+        .
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CompleteMessage_ReturnsHeadersAndBody()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      var messageContent = CreateTestMessage(
+          """
+          From: sender@example.com
+          To: recipient@example.com
+          Subject: Complete Message Test
+          """,
+          """
+          This is the complete body.
+          It has multiple lines.
+          All should be returned.
+          """);
+      messageStore.AddMessage(testMessage, messageContent);
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(1);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = $"""
+        +OK message follows {messageContent.Length} octets
+        From: sender@example.com
+        To: recipient@example.com
+        Subject: Complete Message Test
+
+        This is the complete body.
+        It has multiple lines.
+        All should be returned.
+        .
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipartMimeMessage_ReturnsCompleteMessage()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 500, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+
+      var mimeMessage = """
+                From: sender@example.com
+                To: recipient@example.com
+                Subject: Multipart Email Example
+                Content-Type: multipart/alternative; boundary="boundary-string"
+
+                --boundary-string
+                Content-Type: text/plain; charset="utf-8"
+
+                Plain text email goes here!
+                This is the fallback if email client does not support HTML
+
+                --boundary-string
+                Content-Type: text/html; charset="utf-8"
+
+                <h1>This is the HTML Section!</h1>
+                <p>This is what displays in most modern email clients</p>
+
+                --boundary-string--
+                """;
+
+      var messageContent = Encoding.ASCII.GetBytes(mimeMessage);
+      messageStore.AddMessage(testMessage, messageContent);
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new RetrCommand(1);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      var expected = $"""
+        +OK message follows {messageContent.Length} octets
+        From: sender@example.com
+        To: recipient@example.com
+        Subject: Multipart Email Example
+        Content-Type: multipart/alternative; boundary="boundary-string"
+
+        --boundary-string
+        Content-Type: text/plain; charset="utf-8"
+
+        Plain text email goes here!
+        This is the fallback if email client does not support HTML
+
+        --boundary-string
+        Content-Type: text/html; charset="utf-8"
+
+        <h1>This is the HTML Section!</h1>
+        <p>This is what displays in most modern email clients</p>
+
+        --boundary-string--
+        .
+
+        """;
+      Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public void Constructor_SetsProperties()
+    {
+      // Act
+      var command = new RetrCommand(5);
+
+      // Assert
+      Assert.Equal(5, command.Message);
+      Assert.Equal("RETR", command.Name);
+    }
+
+    #endregion ExecuteAsync Tests
+  }
+}

--- a/src/Pop3Server.Test/TopCommandTests.cs
+++ b/src/Pop3Server.Test/TopCommandTests.cs
@@ -1,0 +1,447 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using Pop3Server.Mail;
+using Pop3Server.Protocol;
+using Pop3Server.Storage;
+using Pop3Server.Test.Helpers;
+
+namespace Pop3Server.Test
+{
+  public class TopCommandTests
+  {
+    private SmtpSessionContext CreateContext(IMessageStore messageStore = null)
+    {
+      var pipe = new Pipe();
+      var serviceProvider = new TestServiceProvider(messageStore ?? new TestMessageStore());
+      var options = new TestPop3ServerOptions();
+      var endpointDefinition = new TestEndpointDefinition();
+
+      var context = new SmtpSessionContext(serviceProvider, options, endpointDefinition)
+      {
+        Pipe = new TestSecurableDuplexPipe(pipe.Reader, pipe.Writer)
+      };
+
+      return context;
+    }
+
+    private byte[] CreateTestMessage(string headers, string body)
+    {
+      var message = $"""
+                {headers}
+
+                {body}
+                """;
+      return Encoding.ASCII.GetBytes(message);
+    }
+
+    private int CountBodyLines(string output)
+    {
+      // Remove the "+OK message follows" line at the beginning
+      var lines = output.Split("\r\n");
+
+      // Find the empty line that separates headers from body
+      var emptyLineIndex = -1;
+      var inHeaders = true;
+      var bodyLineCount = 0;
+
+      for (int i = 1; i < lines.Length; i++) // Start at 1 to skip "+OK"
+      {
+        if (inHeaders && string.IsNullOrEmpty(lines[i]))
+        {
+          inHeaders = false;
+          emptyLineIndex = i;
+          continue;
+        }
+
+        if (!inHeaders)
+        {
+          // Stop at end marker ".",
+          // note: "." could also appear in the body lines themselves (e.g., in file attachments)
+          if (lines[i] == ".")
+            break;
+
+          bodyLineCount++;
+        }
+      }
+
+      return bodyLineCount;
+    }
+
+    #region ExecuteAsync Tests
+
+    [Fact]
+    public async Task ExecuteAsync_ValidMessage_ReturnsOkResponse()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      messageStore.AddMessage(testMessage, CreateTestMessage("Subject: Test", "Body content"));
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(1, 5);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      Assert.Contains("+OK message follows", output);
+      Assert.Contains("Subject: Test", output);
+      Assert.Contains("\r\n.\r\n", output); // End marker
+
+      // Verify: 1 body line present (less than the requested 5, since only 1 line exists in the body)
+      var bodyLines = CountBodyLines(output);
+      Assert.Equal(1, bodyLines);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MessageNumberLessThanOne_ReturnsError()
+    {
+      // Arrange
+      var context = CreateContext();
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+
+      var command = new TopCommand(0, 5);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.False(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      Assert.Contains("-ERR no such message", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MessageNumberGreaterThanCount_ReturnsError()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var context = CreateContext();
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(5, 5); // Request message 5 when only 1 exists
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.False(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      Assert.Contains("-ERR no such message", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeletedMessage_ReturnsError()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = true };
+      var context = CreateContext();
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(1, 5);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.False(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      Assert.Contains("-ERR no such message", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithZeroLines_ReturnsHeadersOnly()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      messageStore.AddMessage(testMessage, CreateTestMessage(
+          """
+          Subject: Test
+          From: test@test.com
+          """,
+          """
+          Body Line 1
+          Body Line 2
+          """));
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(1, 0);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      Assert.Contains("Subject: Test", output);
+      Assert.Contains("From: test@test.com", output);
+      Assert.DoesNotContain("Body Line 1", output);
+
+      // Verify: Exactly 0 body lines
+      var bodyLines = CountBodyLines(output);
+      Assert.Equal(0, bodyLines);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithLimitedLines_ReturnsHeadersAndLimitedBody()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      messageStore.AddMessage(testMessage, CreateTestMessage(
+          "Subject: Test",
+          "Line 1\r\nLine 2\r\nLine 3\r\nLine 4\r\nLine 5"));
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(1, 2);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      Assert.Contains("Subject: Test", output);
+      Assert.Contains("Line 1", output);
+      Assert.Contains("Line 2", output);
+      Assert.DoesNotContain("Line 3", output);
+
+      // Verify: Exactly 2 body lines
+      var bodyLines = CountBodyLines(output);
+      Assert.Equal(2, bodyLines);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipartMime_ZeroLines_ReturnsOnlyHeaders()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 500, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+
+      var mimeMessage = """
+                From: sender@example.com
+                To: recipient@example.com
+                Subject: Multipart Email Example
+                Content-Type: multipart/alternative; boundary="boundary-string"
+
+                --boundary-string
+                Content-Type: text/plain; charset="utf-8"
+                Content-Transfer-Encoding: quoted-printable
+                Content-Disposition: inline
+
+                Plain text email goes here!
+                This is the fallback if email client does not support HTML
+
+                --boundary-string
+                Content-Type: text/html; charset="utf-8"
+                Content-Transfer-Encoding: quoted-printable
+                Content-Disposition: inline
+
+                <h1>This is the HTML Section!</h1>
+                <p>This is what displays in most modern email clients</p>
+
+                --boundary-string--
+                """;
+
+      messageStore.AddMessage(testMessage, Encoding.ASCII.GetBytes(mimeMessage));
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(1, 0);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      // All headers must be present
+      Assert.Contains("From: sender@example.com", output);
+      Assert.Contains("To: recipient@example.com", output);
+      Assert.Contains("Subject: Multipart Email Example", output);
+      Assert.Contains("Content-Type: multipart/alternative", output);
+
+      // NO body lines (everything after the empty line)
+      Assert.DoesNotContain("--boundary-string", output);
+      Assert.DoesNotContain("Plain text email goes here!", output);
+      Assert.DoesNotContain("<h1>This is the HTML Section!</h1>", output);
+
+      // End marker must be present
+      Assert.Contains("\r\n.\r\n", output);
+
+      // Verify: Exactly 0 body lines
+      var bodyLines = CountBodyLines(output);
+      Assert.Equal(0, bodyLines);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipartMime_ThreeLines_ReturnsHeadersAndThreeBodyLines()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 500, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      var mimeMessage = """
+                From: sender@example.com
+                To: recipient@example.com
+                Subject: Multipart Email Example
+                Content-Type: multipart/alternative; boundary="boundary-string"
+
+                --boundary-string
+                Content-Type: text/plain; charset="utf-8"
+                Content-Transfer-Encoding: quoted-printable
+                Content-Disposition: inline
+
+                Plain text email goes here!
+                This is the fallback if email client does not support HTML
+
+                --boundary-string
+                Content-Type: text/html; charset="utf-8"
+                Content-Transfer-Encoding: quoted-printable
+                Content-Disposition: inline
+
+                <h1>This is the HTML Section!</h1>
+                <p>This is what displays in most modern email clients</p>
+
+                --boundary-string--
+                """;
+
+      messageStore.AddMessage(testMessage, Encoding.ASCII.GetBytes(mimeMessage));
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(1, 3);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      // All headers must be present
+      Assert.Contains("From: sender@example.com", output);
+      Assert.Contains("To: recipient@example.com", output);
+      Assert.Contains("Subject: Multipart Email Example", output);
+      Assert.Contains("Content-Type: multipart/alternative", output);
+
+      // First 3 body lines must be present
+      Assert.Contains("--boundary-string", output);
+      Assert.Contains("Content-Type: text/plain", output);
+      Assert.Contains("Content-Transfer-Encoding: quoted-printable", output);
+
+      // Line 4+ should NOT be present
+      Assert.DoesNotContain("Content-Disposition: inline", output);
+      Assert.DoesNotContain("Plain text email goes here!", output);
+      Assert.DoesNotContain("<h1>This is the HTML Section!</h1>", output);
+
+      // End marker must be present
+      Assert.Contains("\r\n.\r\n", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MoreLinesThanAvailable_ReturnsAllAvailableLines()
+    {
+      // Arrange
+      var testMessage = new TestPop3Message { Id = "1", Size = 100, DeleteRequested = false };
+      var messageStore = new TestMessageStore();
+      messageStore.AddMessage(testMessage, CreateTestMessage(
+          "Subject: Test",
+          "Line 1\r\nLine 2\r\nLine 3"));
+
+      var context = CreateContext(messageStore);
+      context.Transaction.Mailbox = new Mailbox("testuser", "test.com");
+      context.Transaction.Messages.Add(testMessage);
+
+      var command = new TopCommand(1, 10000);
+
+      // Act
+      var result = await command.ExecuteAsync(context, CancellationToken.None);
+
+      // Assert
+      Assert.True(result);
+
+      var reader = context.Pipe.Input;
+      var readResult = await reader.ReadAsync();
+      var output = Encoding.ASCII.GetString(readResult.Buffer.ToArray());
+      reader.AdvanceTo(readResult.Buffer.End);
+
+      Assert.Contains("Subject: Test", output);
+      Assert.Contains("Line 1", output);
+      Assert.Contains("Line 2", output);
+      Assert.Contains("Line 3", output);
+      Assert.Contains("\r\n.\r\n", output);
+    }
+
+    [Fact]
+    public void Constructor_SetsProperties()
+    {
+      // Act
+      var command = new TopCommand(5, 10);
+
+      // Assert
+      Assert.Equal(5, command.Message);
+      Assert.Equal(10, command.Lines);
+      Assert.Equal("TOP", command.Name);
+    }
+
+    #endregion ExecuteAsync Tests
+  }
+}

--- a/src/Pop3Server/Extensions/SpanExtensions.cs
+++ b/src/Pop3Server/Extensions/SpanExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Pop3Server.Protocol
+{
+  public static class SpanExtensions
+  {
+    public static int IndexOfNewLine(this ReadOnlySpan<byte> span, char first = (char)13, char second = (char)10)
+    {
+      var maxLength = span.Length - 1;
+      for (int i = 0; i < maxLength; i++)
+        if (span[i] == first && span[i + 1] == second)
+          return i;
+      return -1;
+    }
+
+    public static int IndexOfPair(ReadOnlySpan<char> span, char first, char second)
+    {
+      for (int i = 0; i < span.Length - 1; i++)
+        if (span[i] == first && span[i + 1] == second)
+          return i;
+      return -1;
+    }
+  }
+}

--- a/src/Pop3Server/Pop3Server.csproj
+++ b/src/Pop3Server/Pop3Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>netstandard2.0</TargetFramework>
@@ -36,8 +36,12 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath=""/>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+    <InternalsVisibleTo Include="Pop3Server.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Pop3Server/Pop3Server.csproj
+++ b/src/Pop3Server/Pop3Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	  <TargetFramework>netstandard2.0</TargetFramework>
-	  <LangVersion>8.0</LangVersion>
+	  <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Authors>Michael Lakerveld;Cain O'Sullivan</Authors>
     <Company></Company>
@@ -32,12 +32,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
+		<PackageReference Include="System.IO.Pipelines" Version="10.0.0" />
 	</ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath=""/>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Pop3Server/Protocol/ASCII.cs
+++ b/src/Pop3Server/Protocol/ASCII.cs
@@ -1,0 +1,25 @@
+namespace Pop3Server.Protocol
+{
+  public static class ASCII
+  {
+    /// <summary>
+    /// Carriage return (CR)
+    /// </summary>
+    public const byte CR = 13;
+
+    /// <summary>
+    /// Line feed (LF)
+    /// </summary>
+    public const byte LF = 10;
+
+    /// <summary>
+    /// dot (.)
+    /// </summary>
+    public const byte Dot = 46;
+
+    public static readonly byte[] DotArray = new byte[] { ASCII.Dot };
+    public static readonly byte[] CrLfArray = new byte[] { ASCII.CR, ASCII.LF };
+    public const string NewLine = "\r\n";
+    public const int NewLineLength = 2;
+  }
+}

--- a/src/Pop3Server/Protocol/RetrCommand.cs
+++ b/src/Pop3Server/Protocol/RetrCommand.cs
@@ -9,108 +9,94 @@ using Pop3Server.Storage;
 
 namespace Pop3Server.Protocol
 {
-    public sealed class RetrCommand : SmtpCommand
+  public sealed class RetrCommand : SmtpCommand
+  {
+    public const string Command = "RETR";
+
+    public int Message { get; }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public RetrCommand(int message) : base(Command)
     {
-      public const string Command = "RETR";
-      public readonly byte[] Dot = new byte[] { 46 };
-
-      public int Message { get; }
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        public RetrCommand(int message) : base(Command)
-        {
-          Message = message;
-        }
-
-        /// <summary>
-        /// Execute the command.
-        /// </summary>
-        /// <param name="context">The execution context to operate on.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>Returns true if the command executed successfully such that the transition to the next state should occurr, false
-        /// if the current state is to be maintained.</returns>
-        internal override async Task<bool> ExecuteAsync(SmtpSessionContext context, CancellationToken cancellationToken)
-        {
-            var messageStore = context.ServiceProvider.GetService<IMessageStoreFactory, IMessageStore>(context, MessageStore.Default);
-            using var messageStoreContainer = new DisposableContainer<IMessageStore>(messageStore);
-
-            if (Message < 1)
-                goto noSuchMessage;
-            if (Message > context.Transaction.Messages.Count)
-                goto noSuchMessage;
-
-            var message = context.Transaction.Messages[Message - 1];
-            if (message == null || message.DeleteRequested)
-                goto noSuchMessage;
-
-            //+OK message follows
-
-            var bytes = await messageStoreContainer.Instance.GetAsync(context, context.Transaction.Mailbox, message, cancellationToken).ConfigureAwait(false);
-
-            await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Ok, @$"message follows {bytes.Length} octets"),cancellationToken).ConfigureAwait(false);
-
-            WriteDotStuffed(context, bytes, cancellationToken);
-
-            var ending = new byte[] { 13, 10, 46, 13, 10 };
-
-            context.Pipe.Output.Write(ending);
-
-            await context.Pipe.Output.FlushAsync(cancellationToken).ConfigureAwait(false);
-
-//             await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Ok, @$"{bytes.Length} octets
-// {System.Text.Encoding.ASCII.GetString(bytes)}
-// ."), cancellationToken).ConfigureAwait(false);
-
-            return true;
-
-            // -ERR no such message
-            noSuchMessage:
-            await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Err, "no such message"), cancellationToken).ConfigureAwait(false);
-            return false;
-        }
-
-        private void WriteDotStuffed(SmtpSessionContext context, byte[] data, CancellationToken cancellationToken)
-        {
-          var remaining = new ReadOnlySpan<byte>(data);
-
-          var index = remaining.IndexOfNewLine();
-          while (index >= 0)
-          {
-            if (cancellationToken.IsCancellationRequested)
-              return;
-            var line = remaining.Slice(0, index + 2);
-            if (line.Length > 0 && line.StartsWith(Dot))
-              context.Pipe.Output.Write(Dot);
-            context.Pipe.Output.Write(line);
-
-            remaining = remaining.Slice(index + 2);
-
-            index = remaining.IndexOfNewLine();
-          }
-          context.Pipe.Output.Write(remaining);
-        }
-
+      Message = message;
     }
 
-    public static class SpanExtensions
+    /// <summary>
+    /// Execute the command.
+    /// </summary>
+    /// <param name="context">The execution context to operate on.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Returns true if the command executed successfully such that the transition to the next state should occurr, false
+    /// if the current state is to be maintained.</returns>
+    internal override async Task<bool> ExecuteAsync(SmtpSessionContext context, CancellationToken cancellationToken)
     {
-      public static int IndexOfNewLine(this ReadOnlySpan<byte> span, char first = (char)13, char second = (char)10)
-      {
-        var maxLength = span.Length - 1;
-        for (int i = 0; i < maxLength; i++)
-          if (span[i] == first && span[i + 1] == second)
-            return i;
-        return -1;
-      }
+      var messageStore = context.ServiceProvider.GetService<IMessageStoreFactory, IMessageStore>(context, MessageStore.Default);
+      using var messageStoreContainer = new DisposableContainer<IMessageStore>(messageStore);
 
-      public static int IndexOfPair(ReadOnlySpan<char> span, char first, char second)
+      if (Message < 1)
+        goto noSuchMessage;
+      if (Message > context.Transaction.Messages.Count)
+        goto noSuchMessage;
+
+      var message = context.Transaction.Messages[Message - 1];
+      if (message == null || message.DeleteRequested)
+        goto noSuchMessage;
+
+      //+OK message follows
+
+      var bytes = await messageStoreContainer.Instance.GetAsync(context, context.Transaction.Mailbox, message, cancellationToken).ConfigureAwait(false);
+
+      await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Ok, @$"message follows {bytes.Length} octets"), cancellationToken).ConfigureAwait(false);
+
+      WriteDotStuffed(context, bytes, cancellationToken);
+
+      var ending = new byte[] { 13, 10, 46, 13, 10 };
+
+      context.Pipe.Output.Write(ending);
+
+      await context.Pipe.Output.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+      //             await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Ok, @$"{bytes.Length} octets
+      // {System.Text.Encoding.ASCII.GetString(bytes)}
+      // ."), cancellationToken).ConfigureAwait(false);
+
+      return true;
+
+    // -ERR no such message
+    noSuchMessage:
+      await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Err, "no such message"), cancellationToken).ConfigureAwait(false);
+      return false;
+    }
+
+    private void WriteDotStuffed(SmtpSessionContext context, byte[] data, CancellationToken cancellationToken)
+    {
+      var remaining = new ReadOnlySpan<byte>(data);
+
+      var index = remaining.IndexOfNewLine();
+      while (index >= 0)
       {
-        for (int i = 0; i < span.Length - 1; i++)
-          if (span[i] == first && span[i + 1] == second)
-            return i;
-        return -1;
+        if (cancellationToken.IsCancellationRequested)
+          return;
+        var line = remaining.Slice(0, index + ASCII.NewLineLength);
+        if (line.Length > 0 && line.StartsWith(ASCII.DotArray))
+          context.Pipe.Output.Write(ASCII.DotArray);
+        context.Pipe.Output.Write(line);
+
+        remaining = remaining.Slice(index + ASCII.NewLineLength);
+
+        index = remaining.IndexOfNewLine();
+      }
+      // Handle the last line (no trailing newline)
+      if (remaining.Length > 0)
+      {
+        if (remaining.StartsWith(ASCII.DotArray)) // 46 is '.'
+        {
+          context.Pipe.Output.Write(ASCII.DotArray);
+        }
+        context.Pipe.Output.Write(remaining);
       }
     }
+  }
 }

--- a/src/Pop3Server/Protocol/SmtpParser.cs
+++ b/src/Pop3Server/Protocol/SmtpParser.cs
@@ -10,32 +10,31 @@ using Pop3Server.Text;
 
 namespace Pop3Server.Protocol
 {
-    public sealed class SmtpParser
+  public sealed class SmtpParser
+  {
+    private delegate bool TryMakeDelegate(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse);
+
+    private static readonly SmtpResponse UnrecognizedCommand = new SmtpResponse(SmtpReplyCode.CommandNotImplemented, "Unrecognized command");
+
+    private readonly ISmtpCommandFactory _smtpCommandFactory;
+
+    public SmtpParser(ISmtpCommandFactory smtpCommandFactory)
     {
-        delegate bool TryMakeDelegate(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse);
+      _smtpCommandFactory = smtpCommandFactory;
+    }
 
-        static readonly SmtpResponse UnrecognizedCommand = new SmtpResponse(SmtpReplyCode.CommandNotImplemented, "Unrecognized command");
-
-        readonly ISmtpCommandFactory _smtpCommandFactory;
-
-        public SmtpParser(ISmtpCommandFactory smtpCommandFactory)
-        {
-            _smtpCommandFactory = smtpCommandFactory;
-        }
-
-        /// <summary>
-        /// Make a command from the buffer.
-        /// </summary>
-        /// <param name="buffer">The buffer to read the command from.</param>
-        /// <param name="command">The command that is defined within the token reader.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMake(ref ReadOnlySequence<byte> buffer, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
+    /// <summary>
+    /// Make a command from the buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer to read the command from.</param>
+    /// <param name="command">The command that is defined within the token reader.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMake(ref ReadOnlySequence<byte> buffer, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
       //USER PASS CAPA APOP STAT LIST RETR DELE TOP UIDL AUTH XTND
       //               APOP                              AUTH!XTND
       //USER PASS CAPA      STAT LIST RETR DELE TOP UIDL
-
 
       return Make(buffer, TryMakeUser, out command, out errorResponse)
                 || Make(buffer, TryMakePass, out command, out errorResponse)
@@ -54,464 +53,461 @@ namespace Pop3Server.Protocol
                 || Make(buffer, TryMakeProxy, out command, out errorResponse)
                 || Make(buffer, MakeUnrecognized, out command, out errorResponse);
 
-            static bool Make(ReadOnlySequence<byte> buffer, TryMakeDelegate tryMakeDelegate, out SmtpCommand command, out SmtpResponse errorResponse)
-            {
-                var reader = new TokenReader(buffer);
-
-                return tryMakeDelegate(ref reader, out command, out errorResponse);
-            }
-        }
-
-        static bool MakeUnrecognized(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-            command = null;
-            errorResponse = UnrecognizedCommand;
-
-            return false;
-        }
-
-
-
-        /// <summary>
-        /// Make a QUIT command.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="command">The QUIT command that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeQuit(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-            command = null;
-            errorResponse = null;
-
-            if (reader.TryMake(TryMakeQuitLiteral) == false)
-            {
-                return false;
-            }
-
-            if (TryMakeEnd(ref reader) == false)
-            {
-                errorResponse = SmtpResponse.SyntaxError;
-                return false;
-            }
-
-            command = _smtpCommandFactory.CreateQuit();
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make the QUIT text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the QUIT text sequence could be made, false if not.</returns>
-        public bool TryMakeQuitLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[4];
-                command[0] = 'Q';
-                command[1] = 'U';
-                command[2] = 'I';
-                command[3] = 'T';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Make a NOOP command.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="command">The NOOP command that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeNoop(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-            command = null;
-            errorResponse = null;
-
-            if (reader.TryMake(TryMakeNoopLiteral) == false)
-            {
-                return false;
-            }
-
-            if (TryMakeEnd(ref reader) == false)
-            {
-                errorResponse = SmtpResponse.SyntaxError;
-                return false;
-            }
-
-            command = _smtpCommandFactory.CreateNoop();
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make the NOOP text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the NOOP text sequence could be made, false if not.</returns>
-        public bool TryMakeNoopLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[4];
-                command[0] = 'N';
-                command[1] = 'O';
-                command[2] = 'O';
-                command[3] = 'P';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Make a RSET command.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="command">The RSET command that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeRset(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-            command = null;
-            errorResponse = null;
-
-            if (reader.TryMake(TryMakeRsetLiteral) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (TryMakeEnd(ref reader) == false)
-            {
-                errorResponse = SmtpResponse.SyntaxError;
-                return false;
-            }
-
-            command = _smtpCommandFactory.CreateRset();
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make the RSET text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the RSET text sequence could be made, false if not.</returns>
-        public bool TryMakeRsetLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[4];
-                command[0] = 'R';
-                command[1] = 'S';
-                command[2] = 'E';
-                command[3] = 'T';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Make an STLS command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="command">The STLS command that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeStls(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-            command = null;
-            errorResponse = null;
-
-            if (reader.TryMake(TryMakeStlsLiteral) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (TryMakeEnd(ref reader) == false)
-            {
-                errorResponse = SmtpResponse.SyntaxError;
-                return false;
-            }
-
-            command = _smtpCommandFactory.CreateStls();
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make the STLS text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the STLS text sequence could be made, false if not.</returns>
-        public bool TryMakeStlsLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[4];
-                command[0] = 'S';
-                command[1] = 'T';
-                command[2] = 'L';
-                command[3] = 'S';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Make an USER command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The USER mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeUser(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-            command = null;
-            errorResponse = null;
-            IMailbox mailbox;
-
-            if (reader.TryMake(TryMakeUserLiteral) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (reader.TryMake(TryMakeSomethingText, out var username))
-            {
-              command = _smtpCommandFactory.CreateUser(StringUtil.Create(username));
-              return true;
-            }
-
-            errorResponse = SmtpResponse.SyntaxError;
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make the USER text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the USER text sequence could be made, false if not.</returns>
-        public bool TryMakeUserLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[4];
-                command[0] = 'U';
-                command[1] = 'S';
-                command[2] = 'E';
-                command[3] = 'R';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Make an PASS command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The PASS mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakePass(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
-
-          if (reader.TryMake(TryMakePassLiteral) == false)
-          {
-            return false;
-          }
-
-          reader.Skip(TokenKind.Space);
-
-          if (reader.TryMake(TryMakeSomethingText, out var password))
-          {
-            command = _smtpCommandFactory.CreatePass(StringUtil.Create(password));
-            return true;
-          }
-
-          errorResponse = SmtpResponse.SyntaxError;
-          return false;
-        }
-
-        /// <summary>
-        /// Try to make the PASS text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the PASS text sequence could be made, false if not.</returns>
-        public bool TryMakePassLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[4];
-            command[0] = 'P';
-            command[1] = 'A';
-            command[2] = 'S';
-            command[3] = 'S';
-
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
-
-          return false;
-        }
-
-        /// <summary>
-        /// Make an CAPA command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The CAPA mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeCapa(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
-
-          if (reader.TryMake(TryMakeCapaLiteral) == false)
-          {
-            return false;
-          }
-
-          command = _smtpCommandFactory.CreateCapa();
-          return true;
-        }
-
-        /// <summary>
-        /// Try to make the CAPA text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the CAPA text sequence could be made, false if not.</returns>
-        public bool TryMakeCapaLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[4];
-            command[0] = 'C';
-            command[1] = 'A';
-            command[2] = 'P';
-            command[3] = 'A';
-
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
-
-          return false;
-        }
-
-
-        /// <summary>
-        /// Make an STAT command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The STAT mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeStat(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
-
-          if (reader.TryMake(TryMakeStatLiteral) == false)
-          {
-            return false;
-          }
-
-          command = _smtpCommandFactory.CreateStat();
-          return true;
-        }
-
-        /// <summary>
-        /// Try to make the STAT text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the STAT text sequence could be made, false if not.</returns>
-        public bool TryMakeStatLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[4];
-            command[0] = 'S';
-            command[1] = 'T';
-            command[2] = 'A';
-            command[3] = 'T';
-
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
-
-          return false;
-        }
-
-        /// <summary>
-        /// Make an LIST command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The LIST mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeList(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
-
-          if (reader.TryMake(TryMakeListLiteral) == false)
-          {
-            return false;
-          }
-
-          reader.Skip(TokenKind.Space);
-
-          if (reader.TryMake(TryMakeNumber, out var number))
-          {
-            int.TryParse(StringUtil.Create(number), out var num);
-            command = _smtpCommandFactory.CreateList(num);
-            return true;
-          }
-
-          if (TryMakeEnd(ref reader) == false)
-          {
-              errorResponse = SmtpResponse.SyntaxError;
-              return false;
-          }
-
-          command = _smtpCommandFactory.CreateList(0);
-          return true;
-        }
-
-        /// <summary>
-        /// Try to make the LIST text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the LIST text sequence could be made, false if not.</returns>
-        public bool TryMakeListLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[4];
-            command[0] = 'L';
-            command[1] = 'I';
-            command[2] = 'S';
-            command[3] = 'T';
-
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
-
-          return false;
-        }
-
-        /// <summary>
+      static bool Make(ReadOnlySequence<byte> buffer, TryMakeDelegate tryMakeDelegate, out SmtpCommand command, out SmtpResponse errorResponse)
+      {
+        var reader = new TokenReader(buffer);
+
+        return tryMakeDelegate(ref reader, out command, out errorResponse);
+      }
+    }
+
+    private static bool MakeUnrecognized(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = UnrecognizedCommand;
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make a QUIT command.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="command">The QUIT command that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeQuit(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeQuitLiteral) == false)
+      {
+        return false;
+      }
+
+      if (TryMakeEnd(ref reader) == false)
+      {
+        errorResponse = SmtpResponse.SyntaxError;
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateQuit();
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make the QUIT text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the QUIT text sequence could be made, false if not.</returns>
+    public bool TryMakeQuitLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'Q';
+        command[1] = 'U';
+        command[2] = 'I';
+        command[3] = 'T';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make a NOOP command.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="command">The NOOP command that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeNoop(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeNoopLiteral) == false)
+      {
+        return false;
+      }
+
+      if (TryMakeEnd(ref reader) == false)
+      {
+        errorResponse = SmtpResponse.SyntaxError;
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateNoop();
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make the NOOP text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the NOOP text sequence could be made, false if not.</returns>
+    public bool TryMakeNoopLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'N';
+        command[1] = 'O';
+        command[2] = 'O';
+        command[3] = 'P';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make a RSET command.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="command">The RSET command that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeRset(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeRsetLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (TryMakeEnd(ref reader) == false)
+      {
+        errorResponse = SmtpResponse.SyntaxError;
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateRset();
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make the RSET text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the RSET text sequence could be made, false if not.</returns>
+    public bool TryMakeRsetLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'R';
+        command[1] = 'S';
+        command[2] = 'E';
+        command[3] = 'T';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make an STLS command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="command">The STLS command that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeStls(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeStlsLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (TryMakeEnd(ref reader) == false)
+      {
+        errorResponse = SmtpResponse.SyntaxError;
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateStls();
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make the STLS text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the STLS text sequence could be made, false if not.</returns>
+    public bool TryMakeStlsLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'S';
+        command[1] = 'T';
+        command[2] = 'L';
+        command[3] = 'S';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make an USER command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The USER mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeUser(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+      IMailbox mailbox;
+
+      if (reader.TryMake(TryMakeUserLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(TryMakeSomethingText, out var username))
+      {
+        command = _smtpCommandFactory.CreateUser(StringUtil.Create(username));
+        return true;
+      }
+
+      errorResponse = SmtpResponse.SyntaxError;
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the USER text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the USER text sequence could be made, false if not.</returns>
+    public bool TryMakeUserLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'U';
+        command[1] = 'S';
+        command[2] = 'E';
+        command[3] = 'R';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make an PASS command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The PASS mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakePass(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakePassLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(TryMakeSomethingText, out var password))
+      {
+        command = _smtpCommandFactory.CreatePass(StringUtil.Create(password));
+        return true;
+      }
+
+      errorResponse = SmtpResponse.SyntaxError;
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the PASS text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the PASS text sequence could be made, false if not.</returns>
+    public bool TryMakePassLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'P';
+        command[1] = 'A';
+        command[2] = 'S';
+        command[3] = 'S';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make an CAPA command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The CAPA mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeCapa(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeCapaLiteral) == false)
+      {
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateCapa();
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make the CAPA text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the CAPA text sequence could be made, false if not.</returns>
+    public bool TryMakeCapaLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'C';
+        command[1] = 'A';
+        command[2] = 'P';
+        command[3] = 'A';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make an STAT command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The STAT mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeStat(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeStatLiteral) == false)
+      {
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateStat();
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make the STAT text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the STAT text sequence could be made, false if not.</returns>
+    public bool TryMakeStatLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'S';
+        command[1] = 'T';
+        command[2] = 'A';
+        command[3] = 'T';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Make an LIST command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The LIST mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeList(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeListLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(TryMakeNumber, out var number))
+      {
+        int.TryParse(StringUtil.Create(number), out var num);
+        command = _smtpCommandFactory.CreateList(num);
+        return true;
+      }
+
+      if (TryMakeEnd(ref reader) == false)
+      {
+        errorResponse = SmtpResponse.SyntaxError;
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateList(0);
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make the LIST text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the LIST text sequence could be made, false if not.</returns>
+    public bool TryMakeListLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'L';
+        command[1] = 'I';
+        command[2] = 'S';
+        command[3] = 'T';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
     /// Make an RETR command from the given enumerator.
     /// </summary>
     /// <param name="reader">The reader to perform the operation on.</param>
@@ -519,223 +515,221 @@ namespace Pop3Server.Protocol
     /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
     /// <returns>Returns true if a command could be made, false if not.</returns>
     public bool TryMakeRetr(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
+    {
+      command = null;
+      errorResponse = null;
 
-          if (reader.TryMake(TryMakeRetrLiteral) == false)
-          {
-            return false;
-          }
+      if (reader.TryMake(TryMakeRetrLiteral) == false)
+      {
+        return false;
+      }
 
-          reader.Skip(TokenKind.Space);
+      reader.Skip(TokenKind.Space);
 
-          if (reader.TryMake(TryMakeNumber, out var number))
-          {
-            int.TryParse(StringUtil.Create(number), out var num);
-            command = _smtpCommandFactory.CreateRetr(num);
-            return true;
-          }
+      if (reader.TryMake(TryMakeNumber, out var number))
+      {
+        int.TryParse(StringUtil.Create(number), out var num);
+        command = _smtpCommandFactory.CreateRetr(num);
+        return true;
+      }
 
-          errorResponse = SmtpResponse.SyntaxError;
-          return false;
-        }
+      errorResponse = SmtpResponse.SyntaxError;
+      return false;
+    }
 
-        /// <summary>
-        /// Try to make the RETR text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the RETR text sequence could be made, false if not.</returns>
-        public bool TryMakeRetrLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[4];
-            command[0] = 'R';
-            command[1] = 'E';
-            command[2] = 'T';
-            command[3] = 'R';
+    /// <summary>
+    /// Try to make the RETR text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the RETR text sequence could be made, false if not.</returns>
+    public bool TryMakeRetrLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'R';
+        command[1] = 'E';
+        command[2] = 'T';
+        command[3] = 'R';
 
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
 
-          return false;
-        }
+      return false;
+    }
 
-        /// <summary>
-        /// Make an DELE command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The DELE mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeDele(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
+    /// <summary>
+    /// Make an DELE command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The DELE mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeDele(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
 
-          if (reader.TryMake(TryMakeDeleLiteral) == false)
-          {
-            return false;
-          }
+      if (reader.TryMake(TryMakeDeleLiteral) == false)
+      {
+        return false;
+      }
 
-          reader.Skip(TokenKind.Space);
+      reader.Skip(TokenKind.Space);
 
-          if (reader.TryMake(TryMakeNumber, out var number))
-          {
-            int.TryParse(StringUtil.Create(number), out var num);
-            command = _smtpCommandFactory.CreateDele(num);
-            return true;
-          }
+      if (reader.TryMake(TryMakeNumber, out var number))
+      {
+        int.TryParse(StringUtil.Create(number), out var num);
+        command = _smtpCommandFactory.CreateDele(num);
+        return true;
+      }
 
-          errorResponse = SmtpResponse.SyntaxError;
-          return false;
-        }
+      errorResponse = SmtpResponse.SyntaxError;
+      return false;
+    }
 
-        /// <summary>
-        /// Try to make the DELE text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the DELE text sequence could be made, false if not.</returns>
-        public bool TryMakeDeleLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[4];
-            command[0] = 'D';
-            command[1] = 'E';
-            command[2] = 'L';
-            command[3] = 'E';
+    /// <summary>
+    /// Try to make the DELE text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the DELE text sequence could be made, false if not.</returns>
+    public bool TryMakeDeleLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'D';
+        command[1] = 'E';
+        command[2] = 'L';
+        command[3] = 'E';
 
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
 
-          return false;
-        }
+      return false;
+    }
 
-        /// <summary>
-        /// Make an TOP command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The TOP mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeTop(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
+    /// <summary>
+    /// Make an TOP command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The TOP mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeTop(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
 
-          if (reader.TryMake(TryMakeTopLiteral) == false)
-          {
-            return false;
-          }
+      if (reader.TryMake(TryMakeTopLiteral) == false)
+      {
+        return false;
+      }
 
-          reader.Skip(TokenKind.Space);
+      reader.Skip(TokenKind.Space);
 
-          int num = 0;
-          if (reader.TryMake(TryMakeNumber, out var number))
-          {
-            int.TryParse(StringUtil.Create(number), out num);
-          }
-          else
-          {
-            errorResponse = SmtpResponse.SyntaxError;
-            return false;
-          }
+      int mailIndex = 0;
+      if (reader.TryMake(TryMakeNumber, out var mailIndexStr))
+      {
+        int.TryParse(StringUtil.Create(mailIndexStr), out mailIndex);
+      }
+      else
+      {
+        errorResponse = SmtpResponse.SyntaxError;
+        return false;
+      }
 
-          if (reader.TryMake(TryMakeNumber, out var number2) == false)
-          {
-            command = _smtpCommandFactory.CreateTop(num, 0);
-            return true;
-          }
-          else
-          {
-            int.TryParse(StringUtil.Create(number), out var num2);
-            command = _smtpCommandFactory.CreateTop(num, num2);
-            return true;
-          }
-        }
+      reader.Skip(TokenKind.Space);
 
-        /// <summary>
-        /// Try to make the TOP text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the TOP text sequence could be made, false if not.</returns>
-        public bool TryMakeTopLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[3];
-            command[0] = 'T';
-            command[1] = 'O';
-            command[2] = 'P';
+      if (reader.TryMake(TryMakeNumber, out var linesCountStr) == false)
+      {
+        command = _smtpCommandFactory.CreateTop(mailIndex, 0);
+        return true;
+      }
+      else
+      {
+        int.TryParse(StringUtil.Create(linesCountStr), out var linesCount);
+        command = _smtpCommandFactory.CreateTop(mailIndex, linesCount);
+        return true;
+      }
+    }
 
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
+    /// <summary>
+    /// Try to make the TOP text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the TOP text sequence could be made, false if not.</returns>
+    public bool TryMakeTopLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[3];
+        command[0] = 'T';
+        command[1] = 'O';
+        command[2] = 'P';
 
-          return false;
-        }
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
 
-        /// <summary>
-        /// Make an UIDL command from the given enumerator.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The UIDL mailbox that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeUidl(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-          command = null;
-          errorResponse = null;
+      return false;
+    }
 
-          if (reader.TryMake(TryMakeUidlLiteral) == false)
-          {
-            return false;
-          }
+    /// <summary>
+    /// Make an UIDL command from the given enumerator.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The UIDL mailbox that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeUidl(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
 
-          reader.Skip(TokenKind.Space);
+      if (reader.TryMake(TryMakeUidlLiteral) == false)
+      {
+        return false;
+      }
 
-          if (reader.TryMake(TryMakeNumber, out var number))
-          {
-            int.TryParse(StringUtil.Create(number), out var num);
-            command = _smtpCommandFactory.CreateUidl(num);
-            return true;
-          }
+      reader.Skip(TokenKind.Space);
 
-          if (TryMakeEnd(ref reader) == false)
-          {
-              errorResponse = SmtpResponse.SyntaxError;
-              return false;
-          }
+      if (reader.TryMake(TryMakeNumber, out var number))
+      {
+        int.TryParse(StringUtil.Create(number), out var num);
+        command = _smtpCommandFactory.CreateUidl(num);
+        return true;
+      }
 
-          command = _smtpCommandFactory.CreateUidl(0);
-          return true;
-        }
+      if (TryMakeEnd(ref reader) == false)
+      {
+        errorResponse = SmtpResponse.SyntaxError;
+        return false;
+      }
 
-        /// <summary>
-        /// Try to make the UIDL text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the UIDL text sequence could be made, false if not.</returns>
-        public bool TryMakeUidlLiteral(ref TokenReader reader)
-        {
-          if (reader.TryMake(TryMakeText, out var text))
-          {
-            Span<char> command = stackalloc char[4];
-            command[0] = 'U';
-            command[1] = 'I';
-            command[2] = 'D';
-            command[3] = 'L';
+      command = _smtpCommandFactory.CreateUidl(0);
+      return true;
+    }
 
-            return text.CaseInsensitiveStringEquals(ref command);
-          }
+    /// <summary>
+    /// Try to make the UIDL text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the UIDL text sequence could be made, false if not.</returns>
+    public bool TryMakeUidlLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'U';
+        command[1] = 'I';
+        command[2] = 'D';
+        command[3] = 'L';
 
-          return false;
-        }
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
 
-
-
-
+      return false;
+    }
 
     /// <summary>
     /// Make an AUTH command from the given enumerator.
@@ -745,1451 +739,1447 @@ namespace Pop3Server.Protocol
     /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
     /// <returns>Returns true if a command could be made, false if not.</returns>
     public bool TryMakeAuth(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeAuthLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (TryMakeAuthenticationMethod(ref reader, out var authenticationMethod) == false)
+      {
+        return false;
+      }
+
+      reader.Take();
+
+      if (reader.TryMake(TryMakeEnd))
+      {
+        command = _smtpCommandFactory.CreateAuth(authenticationMethod, null);
+        return true;
+      }
+
+      if (reader.TryMake(TryMakeBase64, out var base64))
+      {
+        command = _smtpCommandFactory.CreateAuth(authenticationMethod, StringUtil.Create(base64));
+        return true;
+      }
+
+      errorResponse = SmtpResponse.SyntaxError;
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the Authentication method.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="authenticationMethod">The authentication method that was made.</param>
+    /// <returns>true if the authentication method could be made, false if not.</returns>
+    public bool TryMakeAuthenticationMethod(ref TokenReader reader, out AuthenticationMethod authenticationMethod)
+    {
+      if (reader.TryMake(TryMakeLoginLiteral))
+      {
+        authenticationMethod = AuthenticationMethod.Login;
+        return true;
+      }
+
+      if (reader.TryMake(TryMakePlainLiteral))
+      {
+        authenticationMethod = AuthenticationMethod.Plain;
+        return true;
+      }
+
+      authenticationMethod = default;
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the AUTH text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the AUTH text sequence could be made, false if not.</returns>
+    public bool TryMakeAuthLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[4];
+        command[0] = 'A';
+        command[1] = 'U';
+        command[2] = 'T';
+        command[3] = 'H';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the LOGIN text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the LOGIN text sequence could be made, false if not.</returns>
+    public bool TryMakeLoginLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[5];
+        command[0] = 'L';
+        command[1] = 'O';
+        command[2] = 'G';
+        command[3] = 'I';
+        command[4] = 'N';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the PLAIN text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the PLAIN text sequence could be made, false if not.</returns>
+    public bool TryMakePlainLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[5];
+        command[0] = 'P';
+        command[1] = 'L';
+        command[2] = 'A';
+        command[3] = 'I';
+        command[4] = 'N';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Support proxy protocol version 1 header for use with HAProxy.
+    /// Documented at http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="command">The PROXY command that is defined within the token enumerator.</param>
+    /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
+    /// <returns>Returns true if a command could be made, false if not.</returns>
+    public bool TryMakeProxy(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
+    {
+      // ABNF
+      // proxy            = "PROXY" space ( unknown-proxy | tcp4-proxy | tcp6-proxy )
+      // unknown-proxy    = "UNKNOWN"
+      // tcp4-proxy       = "TCP4" space ipv4-address-literal space ipv4-address-literal space ip-port-number space ip-port-number
+      // tcp6-proxy       = "TCP6" space ipv6-address-literal space ipv6-address-literal space ip-port-number space ip-port-number
+      // space            = " "
+      // ip-port          = wnum
+      // wnum             = 1*5DIGIT ; in the range of 0-65535
+
+      command = null;
+      errorResponse = null;
+
+      if (reader.TryMake(TryMakeProxyLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(TryMakeUnknownLiteral))
+      {
+        command = _smtpCommandFactory.CreateProxy();
+        return true;
+      }
+
+      if (reader.TryMake(TryMakeTcp4Proxy, out command))
+      {
+        return true;
+      }
+
+      return TryMakeTcp6Proxy(ref reader, out command);
+    }
+
+    /// <summary>
+    /// Try to make the PROXY text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the PROXY text sequence could be made, false if not.</returns>
+    public bool TryMakeProxyLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[5];
+        command[0] = 'P';
+        command[1] = 'R';
+        command[2] = 'O';
+        command[3] = 'X';
+        command[4] = 'Y';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Attempt to make the Unknown Proxy command.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the command was made, false if not.</returns>
+    private bool TryMakeUnknownLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[7];
+        command[0] = 'U';
+        command[1] = 'N';
+        command[2] = 'K';
+        command[3] = 'N';
+        command[4] = 'O';
+        command[5] = 'W';
+        command[6] = 'N';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Attempt to make a TCP4 Proxy command.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="command">The command that was made.</param>
+    /// <returns>true if the command was made, false if not.</returns>
+    public bool TryMakeTcp4Proxy(ref TokenReader reader, out SmtpCommand command)
+    {
+      command = null;
+
+      if (TryMakeTcpLiteral(ref reader) == false)
+      {
+        return false;
+      }
+
+      var token = reader.Take();
+      if (token.Kind != TokenKind.Number && token.Text[0] != '4')
+      {
+        return false;
+      }
+
+      return TryMakeProxyAddresses(ref reader, TryMakeIPv4AddressLiteral, out command);
+    }
+
+    /// <summary>
+    /// Attempt to make a TCP6 Proxy command.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="command">The command that was made.</param>
+    /// <returns>true if the command was made, false if not.</returns>
+    public bool TryMakeTcp6Proxy(ref TokenReader reader, out SmtpCommand command)
+    {
+      command = null;
+
+      if (TryMakeTcpLiteral(ref reader) == false)
+      {
+        return false;
+      }
+
+      var token = reader.Take();
+      if (token.Kind != TokenKind.Number && token.Text[0] != '6')
+      {
+        return false;
+      }
+
+      return TryMakeProxyAddresses(ref reader, TryMakeIPv6Address, out command);
+    }
+
+    /// <summary>
+    /// Attempt to make the proxy address sequences.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="tryMakeDelegate">The delegate to match the address.</param>
+    /// <param name="command">The command that was made.</param>
+    /// <returns>true if the command was made, false if not.</returns>
+    private bool TryMakeProxyAddresses(ref TokenReader reader, TokenReader.TryMakeDelegate tryMakeDelegate, out SmtpCommand command)
+    {
+      command = null;
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(tryMakeDelegate, out var sourceAddress) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(tryMakeDelegate, out var destinationAddress) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(TryMakeWnum, out var sourcePort) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(TryMakeWnum, out var destinationPort) == false)
+      {
+        return false;
+      }
+
+      command = _smtpCommandFactory.CreateProxy(CreateEndpoint(sourceAddress, sourcePort), CreateEndpoint(destinationAddress, destinationPort));
+      return true;
+
+      static IPEndPoint CreateEndpoint(ReadOnlySequence<byte> address, ReadOnlySequence<byte> port)
+      {
+        return new IPEndPoint(IPAddress.Parse(StringUtil.Create(address)), int.Parse(StringUtil.Create(port)));
+      }
+    }
+
+    /// <summary>
+    /// Try to make the Tcp text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the TCP text sequence could be made, false if not.</returns>
+    public bool TryMakeTcpLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[3];
+        command[0] = 'T';
+        command[1] = 'C';
+        command[2] = 'P';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the end of sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the end was made, false if not.</returns>
+    public bool TryMakeEnd(ref TokenReader reader)
+    {
+      reader.Skip(TokenKind.Space);
+
+      return reader.Take().Kind == TokenKind.None;
+    }
+
+    /// <summary>
+    /// Try to make a reverse path.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The mailbox that was made.</param>
+    /// <returns>true if the reverse path was made, false if not.</returns>
+    /// <remarks><![CDATA[Path / "<>"]]></remarks>
+    public bool TryMakeReversePath(ref TokenReader reader, out IMailbox mailbox)
+    {
+      if (reader.TryMake(TryMakePath, out mailbox))
+      {
+        return true;
+      }
+
+      if (TryMakeEmptyPath(ref reader))
+      {
+        mailbox = Mailbox.Empty;
+        return true;
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make an empty path.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the empty path was made, false if not.</returns>
+    /// <remarks><![CDATA["<>"]]></remarks>
+    public bool TryMakeEmptyPath(ref TokenReader reader)
+    {
+      if (reader.Take().Kind != TokenKind.LessThan)
+      {
+        return false;
+      }
+
+      // not valid according to the spec but some senders do it
+      reader.Skip(TokenKind.Space);
+
+      return reader.Take().Kind == TokenKind.GreaterThan;
+    }
+
+    /// <summary>
+    /// Try to make a path.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The mailbox that was made.</param>
+    /// <returns>true if the path was made, false if not.</returns>
+    /// <remarks><![CDATA["<" [ A-d-l ":" ] Mailbox ">"]]></remarks>
+    public bool TryMakePath(ref TokenReader reader, out IMailbox mailbox)
+    {
+      mailbox = null;
+
+      if (reader.Take().Kind != TokenKind.LessThan)
+      {
+        return false;
+      }
+
+      // Note, the at-domain-list must be matched, but also must be ignored
+      // http://tools.ietf.org/html/rfc5321#appendix-C
+      if (reader.TryMake(TryMakeAtDomainList))
+      {
+        // if the @domain list was matched then it needs to be followed by a colon
+        if (reader.Take().Kind != TokenKind.Colon)
         {
-            command = null;
-            errorResponse = null;
-
-            if (reader.TryMake(TryMakeAuthLiteral) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (TryMakeAuthenticationMethod(ref reader, out var authenticationMethod) == false)
-            {
-                return false;
-            }
-
-            reader.Take();
-
-            if (reader.TryMake(TryMakeEnd))
-            {
-                command = _smtpCommandFactory.CreateAuth(authenticationMethod, null);
-                return true;
-            }
-
-            if (reader.TryMake(TryMakeBase64, out var base64))
-            {
-                command = _smtpCommandFactory.CreateAuth(authenticationMethod, StringUtil.Create(base64));
-                return true;
-            }
-
-            errorResponse = SmtpResponse.SyntaxError;
-            return false;
+          return false;
         }
+      }
 
-        /// <summary>
-        /// Try to make the Authentication method.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="authenticationMethod">The authentication method that was made.</param>
-        /// <returns>true if the authentication method could be made, false if not.</returns>
-        public bool TryMakeAuthenticationMethod(ref TokenReader reader, out AuthenticationMethod authenticationMethod)
+      if (TryMakeMailbox(ref reader, out mailbox) == false)
+      {
+        return false;
+      }
+
+      return reader.Take().Kind == TokenKind.GreaterThan;
+    }
+
+    /// <summary>
+    /// Try to make an @domain list.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the @domain list was made, false if not.</returns>
+    /// <remarks><![CDATA[At-domain *( "," At-domain )]]></remarks>
+    public bool TryMakeAtDomainList(ref TokenReader reader)
+    {
+      if (TryMakeAtDomain(ref reader) == false)
+      {
+        return false;
+      }
+
+      while (reader.Peek().Kind == TokenKind.Comma)
+      {
+        reader.Take();
+
+        if (TryMakeAtDomain(ref reader) == false)
         {
-            if (reader.TryMake(TryMakeLoginLiteral))
-            {
-                authenticationMethod = AuthenticationMethod.Login;
-                return true;
-            }
-
-            if (reader.TryMake(TryMakePlainLiteral))
-            {
-                authenticationMethod = AuthenticationMethod.Plain;
-                return true;
-            }
-
-            authenticationMethod = default;
-            return false;
+          return false;
         }
+      }
 
-        /// <summary>
-        /// Try to make the AUTH text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the AUTH text sequence could be made, false if not.</returns>
-        public bool TryMakeAuthLiteral(ref TokenReader reader)
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make an @domain.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the @domain was made, false if not.</returns>
+    /// <remarks><![CDATA["@" Domain]]></remarks>
+    public bool TryMakeAtDomain(ref TokenReader reader)
+    {
+      if (reader.Take().Kind != TokenKind.At)
+      {
+        return false;
+      }
+
+      return TryMakeDomain(ref reader);
+    }
+
+    /// <summary>
+    /// Try to make a mailbox.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="mailbox">The mailbox that was made.</param>
+    /// <returns>true if the mailbox was made, false if not.</returns>
+    /// <remarks><![CDATA[Local-part "@" ( Domain / address-literal )]]></remarks>
+    public bool TryMakeMailbox(ref TokenReader reader, out IMailbox mailbox)
+    {
+      mailbox = null;
+
+      if (reader.TryMake(TryMakeLocalPart, out var localpart) == false)
+      {
+        return false;
+      }
+
+      if (reader.Take().Kind != TokenKind.At)
+      {
+        return false;
+      }
+
+      if (reader.TryMake(TryMakeDomain, out var domain))
+      {
+        mailbox = CreateMailbox(localpart, domain);
+        return true;
+      }
+
+      if (reader.TryMake(TryMakeAddressLiteral, out var address))
+      {
+        mailbox = CreateMailbox(localpart, address);
+        return true;
+      }
+
+      return false;
+
+      static Mailbox CreateMailbox(ReadOnlySequence<byte> localpart, ReadOnlySequence<byte> domainOrAddress)
+      {
+        var user = Regex.Unescape(StringUtil.Create(localpart, Encoding.UTF8).Trim('"'));
+
+        return new Mailbox(user, StringUtil.Create(domainOrAddress));
+      }
+    }
+
+    /// <summary>
+    /// Try to make a domain name.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the domain name was made, false if not.</returns>
+    /// <remarks><![CDATA[sub-domain *("." sub-domain)]]></remarks>
+    public bool TryMakeDomain(ref TokenReader reader)
+    {
+      if (TryMakeSubdomain(ref reader) == false)
+      {
+        return false;
+      }
+
+      while (reader.Peek().Kind == TokenKind.Period)
+      {
+        reader.Take();
+
+        if (TryMakeSubdomain(ref reader) == false)
         {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[4];
-                command[0] = 'A';
-                command[1] = 'U';
-                command[2] = 'T';
-                command[3] = 'H';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
+          return false;
         }
+      }
 
-        /// <summary>
-        /// Try to make the LOGIN text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the LOGIN text sequence could be made, false if not.</returns>
-        public bool TryMakeLoginLiteral(ref TokenReader reader)
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make a subdomain name.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the subdomain name was made, false if not.</returns>
+    /// <remarks><![CDATA[Let-dig [Ldh-str]]]></remarks>
+    public bool TryMakeSubdomain(ref TokenReader reader)
+    {
+      if (TryMakeTextOrNumber(ref reader) == false)
+      {
+        return false;
+      }
+
+      // this is optional
+      reader.TryMake(TryMakeTextOrNumberOrHyphenString);
+
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make a address.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the address was made, false if not.</returns>
+    /// <remarks><![CDATA["[" ( IPv4-address-literal / IPv6-address-literal / General-address-literal ) "]"]]></remarks>
+    public bool TryMakeAddressLiteral(ref TokenReader reader)
+    {
+      if (reader.Take().Kind != TokenKind.LeftBracket)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      if (reader.TryMake(TryMakeIPv4AddressLiteral) == false && reader.TryMake(TryMakeIPv6AddressLiteral) == false)
+      {
+        return false;
+      }
+
+      reader.Skip(TokenKind.Space);
+
+      return reader.Take().Kind == TokenKind.RightBracket;
+    }
+
+    /// <summary>
+    /// Try to make an IPv4 address literal.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the address was made, false if not.</returns>
+    /// <remarks><![CDATA[ Snum 3("."  Snum) ]]></remarks>
+    public bool TryMakeIPv4AddressLiteral(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeSnum) == false)
+      {
+        return false;
+      }
+
+      for (var i = 0; i < 3; i++)
+      {
+        if (reader.Take().Kind != TokenKind.Period)
         {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[5];
-                command[0] = 'L';
-                command[1] = 'O';
-                command[2] = 'G';
-                command[3] = 'I';
-                command[4] = 'N';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make the PLAIN text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the PLAIN text sequence could be made, false if not.</returns>
-        public bool TryMakePlainLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[5];
-                command[0] = 'P';
-                command[1] = 'L';
-                command[2] = 'A';
-                command[3] = 'I';
-                command[4] = 'N';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Support proxy protocol version 1 header for use with HAProxy.
-        /// Documented at http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="command">The PROXY command that is defined within the token enumerator.</param>
-        /// <param name="errorResponse">The error that indicates why the command could not be made.</param>
-        /// <returns>Returns true if a command could be made, false if not.</returns>
-        public bool TryMakeProxy(ref TokenReader reader, out SmtpCommand command, out SmtpResponse errorResponse)
-        {
-            // ABNF
-            // proxy            = "PROXY" space ( unknown-proxy | tcp4-proxy | tcp6-proxy )
-            // unknown-proxy    = "UNKNOWN"
-            // tcp4-proxy       = "TCP4" space ipv4-address-literal space ipv4-address-literal space ip-port-number space ip-port-number
-            // tcp6-proxy       = "TCP6" space ipv6-address-literal space ipv6-address-literal space ip-port-number space ip-port-number
-            // space            = " "
-            // ip-port          = wnum
-            // wnum             = 1*5DIGIT ; in the range of 0-65535
-
-            command = null;
-            errorResponse = null;
-
-            if (reader.TryMake(TryMakeProxyLiteral) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (reader.TryMake(TryMakeUnknownLiteral))
-            {
-                command = _smtpCommandFactory.CreateProxy();
-                return true;
-            }
-
-            if (reader.TryMake(TryMakeTcp4Proxy, out command))
-            {
-                return true;
-            }
-
-            return TryMakeTcp6Proxy(ref reader, out command);
-        }
-
-        /// <summary>
-        /// Try to make the PROXY text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the PROXY text sequence could be made, false if not.</returns>
-        public bool TryMakeProxyLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[5];
-                command[0] = 'P';
-                command[1] = 'R';
-                command[2] = 'O';
-                command[3] = 'X';
-                command[4] = 'Y';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Attempt to make the Unknown Proxy command.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the command was made, false if not.</returns>
-        bool TryMakeUnknownLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[7];
-                command[0] = 'U';
-                command[1] = 'N';
-                command[2] = 'K';
-                command[3] = 'N';
-                command[4] = 'O';
-                command[5] = 'W';
-                command[6] = 'N';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Attempt to make a TCP4 Proxy command.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="command">The command that was made.</param>
-        /// <returns>true if the command was made, false if not.</returns>
-        public bool TryMakeTcp4Proxy(ref TokenReader reader, out SmtpCommand command)
-        {
-            command = null;
-
-            if (TryMakeTcpLiteral(ref reader) == false)
-            {
-                return false;
-            }
-
-            var token = reader.Take();
-            if (token.Kind != TokenKind.Number && token.Text[0] != '4')
-            {
-                return false;
-            }
-
-            return TryMakeProxyAddresses(ref reader, TryMakeIPv4AddressLiteral, out command);
-        }
-
-        /// <summary>
-        /// Attempt to make a TCP6 Proxy command.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="command">The command that was made.</param>
-        /// <returns>true if the command was made, false if not.</returns>
-        public bool TryMakeTcp6Proxy(ref TokenReader reader, out SmtpCommand command)
-        {
-            command = null;
-
-            if (TryMakeTcpLiteral(ref reader) == false)
-            {
-                return false;
-            }
-
-            var token = reader.Take();
-            if (token.Kind != TokenKind.Number && token.Text[0] != '6')
-            {
-                return false;
-            }
-
-            return TryMakeProxyAddresses(ref reader, TryMakeIPv6Address, out command);
-        }
-
-        /// <summary>
-        /// Attempt to make the proxy address sequences.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="tryMakeDelegate">The delegate to match the address.</param>
-        /// <param name="command">The command that was made.</param>
-        /// <returns>true if the command was made, false if not.</returns>
-        bool TryMakeProxyAddresses(ref TokenReader reader, TokenReader.TryMakeDelegate tryMakeDelegate, out SmtpCommand command)
-        {
-            command = null;
-
-            reader.Skip(TokenKind.Space);
-
-            if (reader.TryMake(tryMakeDelegate, out var sourceAddress) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (reader.TryMake(tryMakeDelegate, out var destinationAddress) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (reader.TryMake(TryMakeWnum, out var sourcePort) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (reader.TryMake(TryMakeWnum, out var destinationPort) == false)
-            {
-                return false;
-            }
-
-            command = _smtpCommandFactory.CreateProxy(CreateEndpoint(sourceAddress, sourcePort), CreateEndpoint(destinationAddress, destinationPort));
-            return true;
-
-            static IPEndPoint CreateEndpoint(ReadOnlySequence<byte> address, ReadOnlySequence<byte> port)
-            {
-                return new IPEndPoint(IPAddress.Parse(StringUtil.Create(address)), int.Parse(StringUtil.Create(port)));
-            }
-        }
-
-        /// <summary>
-        /// Try to make the Tcp text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the TCP text sequence could be made, false if not.</returns>
-        public bool TryMakeTcpLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[3];
-                command[0] = 'T';
-                command[1] = 'C';
-                command[2] = 'P';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make the end of sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the end was made, false if not.</returns>
-        public bool TryMakeEnd(ref TokenReader reader)
-        {
-            reader.Skip(TokenKind.Space);
-
-            return reader.Take().Kind == TokenKind.None;
-        }
-
-        /// <summary>
-        /// Try to make a reverse path.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The mailbox that was made.</param>
-        /// <returns>true if the reverse path was made, false if not.</returns>
-        /// <remarks><![CDATA[Path / "<>"]]></remarks>
-        public bool TryMakeReversePath(ref TokenReader reader, out IMailbox mailbox)
-        {
-            if (reader.TryMake(TryMakePath, out mailbox))
-            {
-                return true;
-            }
-
-            if (TryMakeEmptyPath(ref reader))
-            {
-                mailbox = Mailbox.Empty;
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make an empty path.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the empty path was made, false if not.</returns>
-        /// <remarks><![CDATA["<>"]]></remarks>
-        public bool TryMakeEmptyPath(ref TokenReader reader)
-        {
-            if (reader.Take().Kind != TokenKind.LessThan)
-            {
-                return false;
-            }
-
-            // not valid according to the spec but some senders do it
-            reader.Skip(TokenKind.Space);
-
-            return reader.Take().Kind == TokenKind.GreaterThan;
-        }
-
-        /// <summary>
-        /// Try to make a path.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The mailbox that was made.</param>
-        /// <returns>true if the path was made, false if not.</returns>
-        /// <remarks><![CDATA["<" [ A-d-l ":" ] Mailbox ">"]]></remarks>
-        public bool TryMakePath(ref TokenReader reader, out IMailbox mailbox)
-        {
-            mailbox = null;
-
-            if (reader.Take().Kind != TokenKind.LessThan)
-            {
-                return false;
-            }
-
-            // Note, the at-domain-list must be matched, but also must be ignored
-            // http://tools.ietf.org/html/rfc5321#appendix-C
-            if (reader.TryMake(TryMakeAtDomainList))
-            {
-                // if the @domain list was matched then it needs to be followed by a colon
-                if (reader.Take().Kind != TokenKind.Colon)
-                {
-                    return false;
-                }
-            }
-
-            if (TryMakeMailbox(ref reader, out mailbox) == false)
-            {
-                return false;
-            }
-
-            return reader.Take().Kind == TokenKind.GreaterThan;
-        }
-
-        /// <summary>
-        /// Try to make an @domain list.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the @domain list was made, false if not.</returns>
-        /// <remarks><![CDATA[At-domain *( "," At-domain )]]></remarks>
-        public bool TryMakeAtDomainList(ref TokenReader reader)
-        {
-            if (TryMakeAtDomain(ref reader) == false)
-            {
-                return false;
-            }
-
-            while (reader.Peek().Kind == TokenKind.Comma)
-            {
-                reader.Take();
-
-                if (TryMakeAtDomain(ref reader) == false)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make an @domain.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the @domain was made, false if not.</returns>
-        /// <remarks><![CDATA["@" Domain]]></remarks>
-        public bool TryMakeAtDomain(ref TokenReader reader)
-        {
-            if (reader.Take().Kind != TokenKind.At)
-            {
-                return false;
-            }
-
-            return TryMakeDomain(ref reader);
-        }
-
-        /// <summary>
-        /// Try to make a mailbox.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="mailbox">The mailbox that was made.</param>
-        /// <returns>true if the mailbox was made, false if not.</returns>
-        /// <remarks><![CDATA[Local-part "@" ( Domain / address-literal )]]></remarks>
-        public bool TryMakeMailbox(ref TokenReader reader, out IMailbox mailbox)
-        {
-            mailbox = null;
-
-            if (reader.TryMake(TryMakeLocalPart, out var localpart) == false)
-            {
-                return false;
-            }
-
-            if (reader.Take().Kind != TokenKind.At)
-            {
-                return false;
-            }
-
-            if (reader.TryMake(TryMakeDomain, out var domain))
-            {
-                mailbox = CreateMailbox(localpart, domain);
-                return true;
-            }
-
-            if (reader.TryMake(TryMakeAddressLiteral, out var address))
-            {
-                mailbox = CreateMailbox(localpart, address);
-                return true;
-            }
-
-            return false;
-
-            static Mailbox CreateMailbox(ReadOnlySequence<byte> localpart, ReadOnlySequence<byte> domainOrAddress)
-            {
-                var user = Regex.Unescape(StringUtil.Create(localpart, Encoding.UTF8).Trim('"'));
-
-                return new Mailbox(user, StringUtil.Create(domainOrAddress));
-            }
-        }
-
-        /// <summary>
-        /// Try to make a domain name.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the domain name was made, false if not.</returns>
-        /// <remarks><![CDATA[sub-domain *("." sub-domain)]]></remarks>
-        public bool TryMakeDomain(ref TokenReader reader)
-        {
-            if (TryMakeSubdomain(ref reader) == false)
-            {
-                return false;
-            }
-
-            while (reader.Peek().Kind == TokenKind.Period)
-            {
-                reader.Take();
-
-                if (TryMakeSubdomain(ref reader) == false)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make a subdomain name.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the subdomain name was made, false if not.</returns>
-        /// <remarks><![CDATA[Let-dig [Ldh-str]]]></remarks>
-        public bool TryMakeSubdomain(ref TokenReader reader)
-        {
-            if (TryMakeTextOrNumber(ref reader) == false)
-            {
-                return false;
-            }
-
-            // this is optional
-            reader.TryMake(TryMakeTextOrNumberOrHyphenString);
-
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make a address.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the address was made, false if not.</returns>
-        /// <remarks><![CDATA["[" ( IPv4-address-literal / IPv6-address-literal / General-address-literal ) "]"]]></remarks>
-        public bool TryMakeAddressLiteral(ref TokenReader reader)
-        {
-            if (reader.Take().Kind != TokenKind.LeftBracket)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            if (reader.TryMake(TryMakeIPv4AddressLiteral) == false && reader.TryMake(TryMakeIPv6AddressLiteral) == false)
-            {
-                return false;
-            }
-
-            reader.Skip(TokenKind.Space);
-
-            return reader.Take().Kind == TokenKind.RightBracket;
-        }
-
-        /// <summary>
-        /// Try to make an IPv4 address literal.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the address was made, false if not.</returns>
-        /// <remarks><![CDATA[ Snum 3("."  Snum) ]]></remarks>
-        public bool TryMakeIPv4AddressLiteral(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeSnum) == false)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < 3; i++)
-            {
-                if (reader.Take().Kind != TokenKind.Period)
-                {
-                    return false;
-                }
-
-                if (reader.TryMake(TryMakeSnum) == false)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make an Snum (number in the range of 0-255).
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the snum was made, false if not.</returns>
-        /// <remarks><![CDATA[ 1*3DIGIT ]]></remarks>
-        public bool TryMakeSnum(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeNumber, out var number) == false)
-            {
-                return false;
-            }
-
-            return int.TryParse(StringUtil.Create(number), out var snum) && snum >= 0 && snum <= 255;
-        }
-
-        /// <summary>
-        /// Try to make a Wnum (number in the range of 0-65535).
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the snum was made, false if not.</returns>
-        /// <remarks><![CDATA[ 1*5DIGIT ]]></remarks>
-        public bool TryMakeWnum(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeNumber, out var number) == false)
-            {
-                return false;
-            }
-
-            return int.TryParse(StringUtil.Create(number), out var wnum) && wnum >= 0 && wnum <= 65535;
-        }
-
-        /// <summary>
-        /// Try to extract IPv6 address. https://tools.ietf.org/html/rfc4291 section 2.2 used for specification.
-        /// This method expects the address to have the IPv6: prefix.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if a valid Ipv6 address can be extracted.</returns>
-        public bool TryMakeIPv6AddressLiteral(ref TokenReader reader)
-        {
-            if (TryMakeIPv6(ref reader) == false)
-            {
-                return false;
-            }
-
-            if (reader.Take().Kind != TokenKind.Colon)
-            {
-                return false;
-            }
-
-            return TryMakeIPv6Address(ref reader);
-        }
-
-        /// <summary>
-        /// Try to make Ip version from ip version tag which is a formatted text IPv[Version]:
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if ip version tag can be extracted.</returns>
-        public bool TryMakeIPv6(ref TokenReader reader)
-        {
-            if (TryMakeIPv(ref reader) == false)
-            {
-                return false;
-            }
-
-            var token = reader.Take();
-
-            if (token.Kind != TokenKind.Number || token.Text.Length > 1)
-            {
-                return false;
-            }
-
-            return token.Text[0] == '6';
-        }
-
-        /// <summary>
-        /// Try to make the IPv text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if IPv text sequence can be made.</returns>
-        public bool TryMakeIPv(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeText, out var text))
-            {
-                Span<char> command = stackalloc char[3];
-                command[0] = 'I';
-                command[1] = 'P';
-                command[2] = 'v';
-
-                return text.CaseInsensitiveStringEquals(ref command);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make an IPv6 address.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the address was made, false if not.</returns>
-        /// <remarks><![CDATA[  ]]></remarks>
-        public bool TryMakeIPv6Address(ref TokenReader reader)
-        {
-            return reader.TryMake(TryMakeIPv6AddressRule1)
-                || reader.TryMake(TryMakeIPv6AddressRule2)
-                || reader.TryMake(TryMakeIPv6AddressRule3)
-                || reader.TryMake(TryMakeIPv6AddressRule4)
-                || reader.TryMake(TryMakeIPv6AddressRule5)
-                || reader.TryMake(TryMakeIPv6AddressRule6)
-                || reader.TryMake(TryMakeIPv6AddressRule7)
-                || reader.TryMake(TryMakeIPv6AddressRule8)
-                || reader.TryMake(TryMakeIPv6AddressRule9);
-        }
-
-        bool TryMakeIPv6AddressRule1(ref TokenReader reader)
-        {
-            // 6( h16 ":" ) ls32
-            return TryMakeIPv6HexPostamble(ref reader, 6);
-        }
-
-        bool TryMakeIPv6AddressRule2(ref TokenReader reader)
-        {
-            // "::" 5( h16 ":" ) ls32
-            if (reader.Take().Kind != TokenKind.Colon || reader.Take().Kind != TokenKind.Colon)
-            {
-                return false;
-            }
-
-            return TryMakeIPv6HexPostamble(ref reader, 5);
-        }
-
-        bool TryMakeIPv6AddressRule3(ref TokenReader reader)
-        {
-            // [ h16 ] "::" 4( h16 ":" ) ls32
-            if (TryMakeIPv6HexPreamble(ref reader, 1) == false)
-            {
-                return false;
-            }
-
-            return TryMakeIPv6HexPostamble(ref reader, 4);
-        }
-
-        bool TryMakeIPv6AddressRule4(ref TokenReader reader)
-        {
-            // [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
-            if (TryMakeIPv6HexPreamble(ref reader, 2) == false)
-            {
-                return false;
-            }
-
-            return TryMakeIPv6HexPostamble(ref reader, 3);
-        }
-
-        bool TryMakeIPv6AddressRule5(ref TokenReader reader)
-        {
-            // [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
-            if (TryMakeIPv6HexPreamble(ref reader, 3) == false)
-            {
-                return false;
-            }
-
-            return TryMakeIPv6HexPostamble(ref reader, 2);
-        }
-
-        bool TryMakeIPv6AddressRule6(ref TokenReader reader)
-        {
-            // [ *3( h16 ":" ) h16 ] "::" h16 ":" ls32
-            if (TryMakeIPv6HexPreamble(ref reader, 4) == false)
-            {
-                return false;
-            }
-
-            return TryMakeIPv6HexPostamble(ref reader, 1);
-        }
-
-        bool TryMakeIPv6AddressRule7(ref TokenReader reader)
-        {
-            // [ *4( h16 ":" ) h16 ] "::" ls32
-            if (TryMakeIPv6HexPreamble(ref reader, 5) == false)
-            {
-                return false;
-            }
-
-            return TryMakeIPv6Ls32(ref reader);
-        }
-
-        bool TryMakeIPv6AddressRule8(ref TokenReader reader)
-        {
-            // [ *5( h16 ":" ) h16 ] "::" h16
-            if (TryMakeIPv6HexPreamble(ref reader, 6) == false)
-            {
-                return false;
-            }
-
-            return TryMake16BitHex(ref reader);
-        }
-
-        bool TryMakeIPv6AddressRule9(ref TokenReader reader)
-        {
-            // [ *6( h16 ":" ) h16 ] "::"
-            return TryMakeIPv6HexPreamble(ref reader, 7);
-        }
-
-        bool TryMakeIPv6HexPreamble(ref TokenReader reader, int maximum)
-        {
-            for (var i = 0; i < maximum; i++)
-            {
-                if (reader.TryMake(TryMakeTerminal))
-                {
-                    return true;
-                }
-
-                if (i > 0)
-                {
-                    if (reader.Take().Kind != TokenKind.Colon)
-                    {
-                        return false;
-                    }
-                }
-
-                if (TryMake16BitHex(ref reader) == false)
-                {
-                    return false;
-                }
-            }
-
-            return reader.TryMake(TryMakeTerminal);
-
-            static bool TryMakeTerminal(ref TokenReader reader)
-            {
-                return reader.Take().Kind == TokenKind.Colon && reader.Take().Kind == TokenKind.Colon;
-            }
-        }
-
-        bool TryMakeIPv6HexPostamble(ref TokenReader reader, int count)
-        {
-            while (count-- > 0)
-            {
-                if (TryMake16BitHex(ref reader) == false)
-                {
-                    return false;
-                }
-
-                if (reader.Take().Kind != TokenKind.Colon)
-                {
-                    return false;
-                }
-            }
-
-            return TryMakeIPv6Ls32(ref reader);
-        }
-
-        bool TryMakeIPv6Ls32(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeIPv4AddressLiteral))
-            {
-                return true;
-            }
-
-            if (TryMake16BitHex(ref reader) == false)
-            {
-                return false;
-            }
-
-            if (reader.Take().Kind != TokenKind.Colon)
-            {
-                return false;
-            }
-
-            return TryMake16BitHex(ref reader);
-        }
-
-        /// <summary>
-        /// Try to make 16 bit hex number.
-        /// </summary>
-        /// <param name="reader">The token reader to perform the operation on.</param>
-        /// <returns>true if valid hex number can be extracted.</returns>
-        public bool TryMake16BitHex(ref TokenReader reader)
-        {
-            var hexLength = 0L;
-
-            var token = reader.Peek();
-            while ((token.Kind == TokenKind.Text || token.Kind == TokenKind.Number) && hexLength < 4)
-            {
-                if (token.Kind == TokenKind.Text && IsHex(ref token) == false)
-                {
-                    return false;
-                }
-
-                hexLength += reader.Take().Text.Length;
-
-                token = reader.Peek();
-            }
-
-            return hexLength > 0 && hexLength <= 4;
-
-            static bool IsHex(ref Token token)
-            {
-                var span = token.Text;
-
-                return span.IsHex();
-            }
-        }
-
-        /// <summary>
-        /// Try to make a text/number/hyphen string.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operatio on.</param>
-        /// <returns>true if a text, number or hyphen was made, false if not.</returns>
-        /// <remarks><![CDATA[*( ALPHA / DIGIT / "-" ) Let-dig]]></remarks>
-        public bool TryMakeTextOrNumberOrHyphenString(ref TokenReader reader)
-        {
-            var token = reader.Peek();
-
-            if (token.Kind == TokenKind.Text || token.Kind == TokenKind.Number || token.Kind == TokenKind.Hyphen)
-            {
-                reader.Skip(kind => kind == TokenKind.Text || kind == TokenKind.Number || kind == TokenKind.Hyphen);
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make a text or number
-        /// </summary>
-        /// <param name="reader">The reader to perform the operatio on.</param>
-        /// <returns>true if the text or number was made, false if not.</returns>
-        /// <remarks><![CDATA[ALPHA / DIGIT]]></remarks>
-        public bool TryMakeTextOrNumber(ref TokenReader reader)
-        {
-            var token = reader.Peek();
-
-            if (token.Kind == TokenKind.Text)
-            {
-                return TryMakeText(ref reader);
-            }
-
-            if (token.Kind == TokenKind.Number)
-            {
-                return TryMakeNumber(ref reader);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make the local part of the path.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operatio on.</param>
-        /// <returns>true if the local part was made, false if not.</returns>
-        /// <remarks><![CDATA[Dot-string / Quoted-string]]></remarks>
-        public bool TryMakeLocalPart(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeDotString))
-            {
-                return true;
-            }
-
-            return TryMakeQuotedString(ref reader);
-        }
-
-        /// <summary>
-        /// Try to make a dot-string from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the dot-string was made, false if not.</returns>
-        /// <remarks><![CDATA[Atom *("."  Atom)]]></remarks>
-        public bool TryMakeDotString(ref TokenReader reader)
-        {
-            if (TryMakeAtom(ref reader) == false)
-            {
-                return false;
-            }
-
-            while (reader.Peek().Kind == TokenKind.Period)
-            {
-                reader.Take();
-
-                if (TryMakeAtom(ref reader) == false)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make a quoted-string from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the quoted-string was made, false if not.</returns>
-        /// <remarks><![CDATA[DQUOTE * QcontentSMTP DQUOTE]]></remarks>
-        public bool TryMakeQuotedString(ref TokenReader reader)
-        {
-            if (reader.Take().Kind != TokenKind.Quote)
-            {
-                return false;
-            }
-
-            while (reader.Peek().Kind != TokenKind.Quote)
-            {
-                if (TryMakeQContentSmtp(ref reader) == false)
-                {
-                    return false;
-                }
-            }
-
-            return reader.Take().Kind == TokenKind.Quote;
-        }
-
-        /// <summary>
-        /// Try to make a QcontentSMTP from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the quoted content was made, false if not.</returns>
-        /// <remarks><![CDATA[qtextSMTP / quoted-pairSMTP]]></remarks>
-        public bool TryMakeQContentSmtp(ref TokenReader reader)
-        {
-            if (reader.TryMake(TryMakeQTextSmtp))
-            {
-                return true;
-            }
-
-            return TryMakeQuotedPairSmtp(ref reader);
-        }
-
-        /// <summary>
-        /// Try to make a QTextSMTP from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the quoted text was made, false if not.</returns>
-        /// <remarks><![CDATA[%d32-33 / %d35-91 / %d93-126]]></remarks>
-        public bool TryMakeQTextSmtp(ref TokenReader reader)
-        {
-            if (reader.Peek().Kind == TokenKind.None)
-            {
-                return false;
-            }
-
-            switch (reader.Peek().Kind)
-            {
-                case TokenKind.Text:
-                    return TryMakeText(ref reader);
-
-                case TokenKind.Number:
-                    return TryMakeNumber(ref reader);
-
-                default:
-                    var token = reader.Take();
-                    switch ((char)token.Text[0])
-                    {
-                        case ' ':
-                        case '!':
-                        case '#':
-                        case '$':
-                        case '%':
-                        case '&':
-                        case '\'':
-                        case '(':
-                        case ')':
-                        case '*':
-                        case '+':
-                        case ',':
-                        case '-':
-                        case '.':
-                        case '/':
-                        case ':':
-                        case ';':
-                        case '<':
-                        case '=':
-                        case '>':
-                        case '?':
-                        case '@':
-                        case '[':
-                        case ']':
-                        case '^':
-                        case '_':
-                        case '`':
-                        case '{':
-                        case '|':
-                        case '}':
-                        case '~':
-                            return true;
-                    }
-                    break;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make a quoted pair from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the quoted pair was made, false if not.</returns>
-        /// <remarks><![CDATA[%d92 %d32-126]]></remarks>
-        public bool TryMakeQuotedPairSmtp(ref TokenReader reader)
-        {
-            if (reader.Take().Kind != TokenKind.Backslash)
-            {
-                return false;
-            }
-
-            var token = reader.Take();
-
-            return token.Text.Length > 0 && token.Text[0] >= 32 && token.Text[0] <= 126;
-        }
-
-        /// <summary>
-        /// Try to make an "Atom" from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the atom was made, false if not.</returns>
-        /// <remarks><![CDATA[1*atext]]></remarks>
-        public bool TryMakeAtom(ref TokenReader reader)
-        {
-            var count = 0;
-
-            while (reader.TryMake(TryMakeAtext))
-            {
-                count++;
-            }
-
-            return count >= 1;
-        }
-
-        /// <summary>
-        /// Try to make an "Atext" from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the atext was made, false if not.</returns>
-        /// <remarks><![CDATA[atext]]></remarks>
-        public bool TryMakeAtext(ref TokenReader reader)
-        {
-            var peek = reader.Peek();
-
-            switch (peek.Kind)
-            {
-                case TokenKind.None:
-                    return false;
-
-                case TokenKind.Text:
-                    return TryMakeText(ref reader);
-
-                case TokenKind.Number:
-                    return TryMakeNumber(ref reader);
-
-                default:
-                    var token = reader.Take();
-                    switch ((char)token.Text[0])
-                    {
-                        case '!':
-                        case '#':
-                        case '%':
-                        case '&':
-                        case '\'':
-                        case '*':
-                        case '-':
-                        case '/':
-                        case '?':
-                        case '_':
-                        case '{':
-                        case '}':
-                        case '$':
-                        case '+':
-                        case '=':
-                        case '^':
-                        case '`':
-                        case '|':
-                        case '~':
-                            return true;
-                    }
-                    break;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make an Mail-Parameters from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="parameters">The mail parameters that were made.</param>
-        /// <returns>true if the mail parameters can be made, false if not.</returns>
-        /// <remarks><![CDATA[esmtp-param *(SP esmtp-param)]]></remarks>
-        public bool TryMakeMailParameters(ref TokenReader reader, out IReadOnlyDictionary<string, string> parameters)
-        {
-            Dictionary<string, string> dictionary = null;
-
-            while (reader.Peek().Kind != TokenKind.None)
-            {
-                if (reader.TryMake(TryMakeEsmtpParameter, out ReadOnlySequence<byte> keyword, out ReadOnlySequence<byte> value) == false)
-                {
-                    parameters = null;
-                    return false;
-                }
-
-                dictionary ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                dictionary.Add(StringUtil.Create(keyword), StringUtil.Create(value));
-
-                reader.Skip(TokenKind.Space);
-            }
-
-            parameters = dictionary;
-            return parameters?.Count > 0;
-        }
-
-        /// <summary>
-        /// Try to make an Esmtp-Parameter from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <param name="keyword">The keyword that was made.</param>
-        /// <param name="value">The value that was made.</param>
-        /// <returns>true if the esmtp-parameter can be made, false if not.</returns>
-        /// <remarks><![CDATA[esmtp-keyword ["=" esmtp-value]]]></remarks>
-        public bool TryMakeEsmtpParameter(ref TokenReader reader, out ReadOnlySequence<byte> keyword, out ReadOnlySequence<byte> value)
-        {
-            value = default;
-
-            if (reader.TryMake(TryMakeEsmtpKeyword, out keyword) == false)
-            {
-                return false;
-            }
-
-            if (reader.Peek().Kind == TokenKind.None || reader.Peek().Kind == TokenKind.Space)
-            {
-                return true;
-            }
-
-            if (reader.Take().Kind != TokenKind.Equal)
-            {
-                return false;
-            }
-
-            return reader.TryMake(TryMakeEsmtpValue, out value);
-        }
-
-        /// <summary>
-        /// Try to make an Esmtp-Keyword from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the esmtp-keyword can be made, false if not.</returns>
-        /// <remarks><![CDATA[(ALPHA / DIGIT) *(ALPHA / DIGIT / "-")]]></remarks>
-        public bool TryMakeEsmtpKeyword(ref TokenReader reader)
-        {
-            var token = reader.Take();
-            if (token.Kind != TokenKind.Text && token.Kind != TokenKind.Number)
-            {
-                return false;
-            }
-
-            token = reader.Peek();
-            while (token.Kind == TokenKind.Text || token.Kind == TokenKind.Number || token.Kind == TokenKind.Hyphen)
-            {
-                reader.Take();
-                token = reader.Peek();
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make an Esmtp-Value from the tokens.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the esmtp-value can be made, false if not.</returns>
-        /// <remarks><![CDATA[1*(%d33-60 / %d62-127)]]></remarks>
-        public bool TryMakeEsmtpValue(ref TokenReader reader)
-        {
-            var token = reader.Take();
-            if (token.Kind == TokenKind.None || IsValid(ref token) == false)
-            {
-                return false;
-            }
-
-            token = reader.Peek();
-            while (token.Kind != TokenKind.None && IsValid(ref token))
-            {
-                reader.Take();
-
-                token = reader.Peek();
-            }
-
-            return true;
-
-            static bool IsValid(ref Token token)
-            {
-                var span = token.Text;
-
-                for (var i = 0; i < span.Length; i++)
-                {
-                    if ((span[i] < 33 || span[i] > 60) && (span[i] < 62 || span[i] > 127))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// Try to make a base64 encoded string.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the base64 encoded string can be made, false if not.</returns>
-        /// <remarks><![CDATA[ALPHA / DIGIT / "+" / "/"]]></remarks>
-        public bool TryMakeBase64(ref TokenReader reader)
-        {
-            if (TryMakeBase64Text(ref reader) == false)
-            {
-                return false;
-            }
-
-            if (reader.Peek().Kind == TokenKind.Equal)
-            {
-                reader.Take();
-            }
-
-            if (reader.Peek().Kind == TokenKind.Equal)
-            {
-                reader.Take();
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Try to make a base64 encoded string.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the base64 encoded string can be made, false if not.</returns>
-        /// <remarks><![CDATA[ALPHA / DIGIT / "+" / "/"]]></remarks>
-        public bool TryMakeBase64Text(ref TokenReader reader)
-        {
-            var count = 0;
-
-            while (reader.TryMake(TryMakeBase64Chars))
-            {
-                count++;
-            }
-
-            return count > 0;
-        }
-
-        /// <summary>
-        /// Try to make the allowable characters in a base64 encoded string.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if the base64-chars can be made, false if not.</returns>
-        /// <remarks><![CDATA[ALPHA / DIGIT / "+" / "/"]]></remarks>
-        public bool TryMakeBase64Chars(ref TokenReader reader)
-        {
-            var token = reader.Take();
-
-            switch (token.Kind)
-            {
-                case TokenKind.Text:
-                case TokenKind.Number:
-                case TokenKind.Slash:
-                case TokenKind.Plus:
-                    return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make a text sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if a text sequence could be made, false if not.</returns>
-        public bool TryMakeText(ref TokenReader reader)
-        {
-            if (reader.Peek().Kind == TokenKind.Text)
-            {
-                reader.Skip(TokenKind.Text);
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Try to make a number sequence.
-        /// </summary>
-        /// <param name="reader">The reader to perform the operation on.</param>
-        /// <returns>true if a number sequence could be made, false if not.</returns>
-        public bool TryMakeNumber(ref TokenReader reader)
-        {
-            if (reader.Peek().Kind == TokenKind.Number)
-            {
-                reader.Skip(TokenKind.Number);
-                return true;
-            }
-
-            return false;
-        }
-
-
-
-        public bool TryMakeSomethingText(ref TokenReader reader)
-        {
-          var count = 0;
-
-          while (reader.TryMake(TryMakeSomethingChars))
-          {
-            count++;
-          }
-
-          return count > 0;
-        }
-
-        public bool TryMakeSomethingChars(ref TokenReader reader)
-        {
-          var token = reader.Take();
-
-          switch (token.Kind)
-          {
-            case TokenKind.Text:
-            case TokenKind.Number:
-            case TokenKind.Space:
-            case TokenKind.Hyphen:
-            case TokenKind.Period:
-            case TokenKind.LeftBracket:
-            case TokenKind.RightBracket:
-            case TokenKind.Colon:
-            case TokenKind.GreaterThan:
-            case TokenKind.LessThan:
-            case TokenKind.Comma:
-            case TokenKind.At:
-            case TokenKind.Quote:
-            case TokenKind.Equal:
-            case TokenKind.Slash:
-            case TokenKind.Backslash:
-            case TokenKind.Plus:
-              return true;
-          }
-
           return false;
         }
 
+        if (reader.TryMake(TryMakeSnum) == false)
+        {
+          return false;
+        }
+      }
 
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make an Snum (number in the range of 0-255).
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the snum was made, false if not.</returns>
+    /// <remarks><![CDATA[ 1*3DIGIT ]]></remarks>
+    public bool TryMakeSnum(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeNumber, out var number) == false)
+      {
+        return false;
+      }
+
+      return int.TryParse(StringUtil.Create(number), out var snum) && snum >= 0 && snum <= 255;
+    }
+
+    /// <summary>
+    /// Try to make a Wnum (number in the range of 0-65535).
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the snum was made, false if not.</returns>
+    /// <remarks><![CDATA[ 1*5DIGIT ]]></remarks>
+    public bool TryMakeWnum(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeNumber, out var number) == false)
+      {
+        return false;
+      }
+
+      return int.TryParse(StringUtil.Create(number), out var wnum) && wnum >= 0 && wnum <= 65535;
+    }
+
+    /// <summary>
+    /// Try to extract IPv6 address. https://tools.ietf.org/html/rfc4291 section 2.2 used for specification.
+    /// This method expects the address to have the IPv6: prefix.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if a valid Ipv6 address can be extracted.</returns>
+    public bool TryMakeIPv6AddressLiteral(ref TokenReader reader)
+    {
+      if (TryMakeIPv6(ref reader) == false)
+      {
+        return false;
+      }
+
+      if (reader.Take().Kind != TokenKind.Colon)
+      {
+        return false;
+      }
+
+      return TryMakeIPv6Address(ref reader);
+    }
+
+    /// <summary>
+    /// Try to make Ip version from ip version tag which is a formatted text IPv[Version]:
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if ip version tag can be extracted.</returns>
+    public bool TryMakeIPv6(ref TokenReader reader)
+    {
+      if (TryMakeIPv(ref reader) == false)
+      {
+        return false;
+      }
+
+      var token = reader.Take();
+
+      if (token.Kind != TokenKind.Number || token.Text.Length > 1)
+      {
+        return false;
+      }
+
+      return token.Text[0] == '6';
+    }
+
+    /// <summary>
+    /// Try to make the IPv text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if IPv text sequence can be made.</returns>
+    public bool TryMakeIPv(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeText, out var text))
+      {
+        Span<char> command = stackalloc char[3];
+        command[0] = 'I';
+        command[1] = 'P';
+        command[2] = 'v';
+
+        return text.CaseInsensitiveStringEquals(ref command);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make an IPv6 address.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the address was made, false if not.</returns>
+    /// <remarks><![CDATA[  ]]></remarks>
+    public bool TryMakeIPv6Address(ref TokenReader reader)
+    {
+      return reader.TryMake(TryMakeIPv6AddressRule1)
+          || reader.TryMake(TryMakeIPv6AddressRule2)
+          || reader.TryMake(TryMakeIPv6AddressRule3)
+          || reader.TryMake(TryMakeIPv6AddressRule4)
+          || reader.TryMake(TryMakeIPv6AddressRule5)
+          || reader.TryMake(TryMakeIPv6AddressRule6)
+          || reader.TryMake(TryMakeIPv6AddressRule7)
+          || reader.TryMake(TryMakeIPv6AddressRule8)
+          || reader.TryMake(TryMakeIPv6AddressRule9);
+    }
+
+    private bool TryMakeIPv6AddressRule1(ref TokenReader reader)
+    {
+      // 6( h16 ":" ) ls32
+      return TryMakeIPv6HexPostamble(ref reader, 6);
+    }
+
+    private bool TryMakeIPv6AddressRule2(ref TokenReader reader)
+    {
+      // "::" 5( h16 ":" ) ls32
+      if (reader.Take().Kind != TokenKind.Colon || reader.Take().Kind != TokenKind.Colon)
+      {
+        return false;
+      }
+
+      return TryMakeIPv6HexPostamble(ref reader, 5);
+    }
+
+    private bool TryMakeIPv6AddressRule3(ref TokenReader reader)
+    {
+      // [ h16 ] "::" 4( h16 ":" ) ls32
+      if (TryMakeIPv6HexPreamble(ref reader, 1) == false)
+      {
+        return false;
+      }
+
+      return TryMakeIPv6HexPostamble(ref reader, 4);
+    }
+
+    private bool TryMakeIPv6AddressRule4(ref TokenReader reader)
+    {
+      // [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+      if (TryMakeIPv6HexPreamble(ref reader, 2) == false)
+      {
+        return false;
+      }
+
+      return TryMakeIPv6HexPostamble(ref reader, 3);
+    }
+
+    private bool TryMakeIPv6AddressRule5(ref TokenReader reader)
+    {
+      // [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+      if (TryMakeIPv6HexPreamble(ref reader, 3) == false)
+      {
+        return false;
+      }
+
+      return TryMakeIPv6HexPostamble(ref reader, 2);
+    }
+
+    private bool TryMakeIPv6AddressRule6(ref TokenReader reader)
+    {
+      // [ *3( h16 ":" ) h16 ] "::" h16 ":" ls32
+      if (TryMakeIPv6HexPreamble(ref reader, 4) == false)
+      {
+        return false;
+      }
+
+      return TryMakeIPv6HexPostamble(ref reader, 1);
+    }
+
+    private bool TryMakeIPv6AddressRule7(ref TokenReader reader)
+    {
+      // [ *4( h16 ":" ) h16 ] "::" ls32
+      if (TryMakeIPv6HexPreamble(ref reader, 5) == false)
+      {
+        return false;
+      }
+
+      return TryMakeIPv6Ls32(ref reader);
+    }
+
+    private bool TryMakeIPv6AddressRule8(ref TokenReader reader)
+    {
+      // [ *5( h16 ":" ) h16 ] "::" h16
+      if (TryMakeIPv6HexPreamble(ref reader, 6) == false)
+      {
+        return false;
+      }
+
+      return TryMake16BitHex(ref reader);
+    }
+
+    private bool TryMakeIPv6AddressRule9(ref TokenReader reader)
+    {
+      // [ *6( h16 ":" ) h16 ] "::"
+      return TryMakeIPv6HexPreamble(ref reader, 7);
+    }
+
+    private bool TryMakeIPv6HexPreamble(ref TokenReader reader, int maximum)
+    {
+      for (var i = 0; i < maximum; i++)
+      {
+        if (reader.TryMake(TryMakeTerminal))
+        {
+          return true;
+        }
+
+        if (i > 0)
+        {
+          if (reader.Take().Kind != TokenKind.Colon)
+          {
+            return false;
+          }
+        }
+
+        if (TryMake16BitHex(ref reader) == false)
+        {
+          return false;
+        }
+      }
+
+      return reader.TryMake(TryMakeTerminal);
+
+      static bool TryMakeTerminal(ref TokenReader reader)
+      {
+        return reader.Take().Kind == TokenKind.Colon && reader.Take().Kind == TokenKind.Colon;
+      }
+    }
+
+    private bool TryMakeIPv6HexPostamble(ref TokenReader reader, int count)
+    {
+      while (count-- > 0)
+      {
+        if (TryMake16BitHex(ref reader) == false)
+        {
+          return false;
+        }
+
+        if (reader.Take().Kind != TokenKind.Colon)
+        {
+          return false;
+        }
+      }
+
+      return TryMakeIPv6Ls32(ref reader);
+    }
+
+    private bool TryMakeIPv6Ls32(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeIPv4AddressLiteral))
+      {
+        return true;
+      }
+
+      if (TryMake16BitHex(ref reader) == false)
+      {
+        return false;
+      }
+
+      if (reader.Take().Kind != TokenKind.Colon)
+      {
+        return false;
+      }
+
+      return TryMake16BitHex(ref reader);
+    }
+
+    /// <summary>
+    /// Try to make 16 bit hex number.
+    /// </summary>
+    /// <param name="reader">The token reader to perform the operation on.</param>
+    /// <returns>true if valid hex number can be extracted.</returns>
+    public bool TryMake16BitHex(ref TokenReader reader)
+    {
+      var hexLength = 0L;
+
+      var token = reader.Peek();
+      while ((token.Kind == TokenKind.Text || token.Kind == TokenKind.Number) && hexLength < 4)
+      {
+        if (token.Kind == TokenKind.Text && IsHex(ref token) == false)
+        {
+          return false;
+        }
+
+        hexLength += reader.Take().Text.Length;
+
+        token = reader.Peek();
+      }
+
+      return hexLength > 0 && hexLength <= 4;
+
+      static bool IsHex(ref Token token)
+      {
+        var span = token.Text;
+
+        return span.IsHex();
+      }
+    }
+
+    /// <summary>
+    /// Try to make a text/number/hyphen string.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operatio on.</param>
+    /// <returns>true if a text, number or hyphen was made, false if not.</returns>
+    /// <remarks><![CDATA[*( ALPHA / DIGIT / "-" ) Let-dig]]></remarks>
+    public bool TryMakeTextOrNumberOrHyphenString(ref TokenReader reader)
+    {
+      var token = reader.Peek();
+
+      if (token.Kind == TokenKind.Text || token.Kind == TokenKind.Number || token.Kind == TokenKind.Hyphen)
+      {
+        reader.Skip(kind => kind == TokenKind.Text || kind == TokenKind.Number || kind == TokenKind.Hyphen);
+        return true;
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make a text or number
+    /// </summary>
+    /// <param name="reader">The reader to perform the operatio on.</param>
+    /// <returns>true if the text or number was made, false if not.</returns>
+    /// <remarks><![CDATA[ALPHA / DIGIT]]></remarks>
+    public bool TryMakeTextOrNumber(ref TokenReader reader)
+    {
+      var token = reader.Peek();
+
+      if (token.Kind == TokenKind.Text)
+      {
+        return TryMakeText(ref reader);
+      }
+
+      if (token.Kind == TokenKind.Number)
+      {
+        return TryMakeNumber(ref reader);
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make the local part of the path.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operatio on.</param>
+    /// <returns>true if the local part was made, false if not.</returns>
+    /// <remarks><![CDATA[Dot-string / Quoted-string]]></remarks>
+    public bool TryMakeLocalPart(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeDotString))
+      {
+        return true;
+      }
+
+      return TryMakeQuotedString(ref reader);
+    }
+
+    /// <summary>
+    /// Try to make a dot-string from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the dot-string was made, false if not.</returns>
+    /// <remarks><![CDATA[Atom *("."  Atom)]]></remarks>
+    public bool TryMakeDotString(ref TokenReader reader)
+    {
+      if (TryMakeAtom(ref reader) == false)
+      {
+        return false;
+      }
+
+      while (reader.Peek().Kind == TokenKind.Period)
+      {
+        reader.Take();
+
+        if (TryMakeAtom(ref reader) == false)
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make a quoted-string from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the quoted-string was made, false if not.</returns>
+    /// <remarks><![CDATA[DQUOTE * QcontentSMTP DQUOTE]]></remarks>
+    public bool TryMakeQuotedString(ref TokenReader reader)
+    {
+      if (reader.Take().Kind != TokenKind.Quote)
+      {
+        return false;
+      }
+
+      while (reader.Peek().Kind != TokenKind.Quote)
+      {
+        if (TryMakeQContentSmtp(ref reader) == false)
+        {
+          return false;
+        }
+      }
+
+      return reader.Take().Kind == TokenKind.Quote;
+    }
+
+    /// <summary>
+    /// Try to make a QcontentSMTP from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the quoted content was made, false if not.</returns>
+    /// <remarks><![CDATA[qtextSMTP / quoted-pairSMTP]]></remarks>
+    public bool TryMakeQContentSmtp(ref TokenReader reader)
+    {
+      if (reader.TryMake(TryMakeQTextSmtp))
+      {
+        return true;
+      }
+
+      return TryMakeQuotedPairSmtp(ref reader);
+    }
+
+    /// <summary>
+    /// Try to make a QTextSMTP from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the quoted text was made, false if not.</returns>
+    /// <remarks><![CDATA[%d32-33 / %d35-91 / %d93-126]]></remarks>
+    public bool TryMakeQTextSmtp(ref TokenReader reader)
+    {
+      if (reader.Peek().Kind == TokenKind.None)
+      {
+        return false;
+      }
+
+      switch (reader.Peek().Kind)
+      {
+        case TokenKind.Text:
+          return TryMakeText(ref reader);
+
+        case TokenKind.Number:
+          return TryMakeNumber(ref reader);
+
+        default:
+          var token = reader.Take();
+          switch ((char)token.Text[0])
+          {
+            case ' ':
+            case '!':
+            case '#':
+            case '$':
+            case '%':
+            case '&':
+            case '\'':
+            case '(':
+            case ')':
+            case '*':
+            case '+':
+            case ',':
+            case '-':
+            case '.':
+            case '/':
+            case ':':
+            case ';':
+            case '<':
+            case '=':
+            case '>':
+            case '?':
+            case '@':
+            case '[':
+            case ']':
+            case '^':
+            case '_':
+            case '`':
+            case '{':
+            case '|':
+            case '}':
+            case '~':
+              return true;
+          }
+          break;
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make a quoted pair from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the quoted pair was made, false if not.</returns>
+    /// <remarks><![CDATA[%d92 %d32-126]]></remarks>
+    public bool TryMakeQuotedPairSmtp(ref TokenReader reader)
+    {
+      if (reader.Take().Kind != TokenKind.Backslash)
+      {
+        return false;
+      }
+
+      var token = reader.Take();
+
+      return token.Text.Length > 0 && token.Text[0] >= 32 && token.Text[0] <= 126;
+    }
+
+    /// <summary>
+    /// Try to make an "Atom" from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the atom was made, false if not.</returns>
+    /// <remarks><![CDATA[1*atext]]></remarks>
+    public bool TryMakeAtom(ref TokenReader reader)
+    {
+      var count = 0;
+
+      while (reader.TryMake(TryMakeAtext))
+      {
+        count++;
+      }
+
+      return count >= 1;
+    }
+
+    /// <summary>
+    /// Try to make an "Atext" from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the atext was made, false if not.</returns>
+    /// <remarks><![CDATA[atext]]></remarks>
+    public bool TryMakeAtext(ref TokenReader reader)
+    {
+      var peek = reader.Peek();
+
+      switch (peek.Kind)
+      {
+        case TokenKind.None:
+          return false;
+
+        case TokenKind.Text:
+          return TryMakeText(ref reader);
+
+        case TokenKind.Number:
+          return TryMakeNumber(ref reader);
+
+        default:
+          var token = reader.Take();
+          switch ((char)token.Text[0])
+          {
+            case '!':
+            case '#':
+            case '%':
+            case '&':
+            case '\'':
+            case '*':
+            case '-':
+            case '/':
+            case '?':
+            case '_':
+            case '{':
+            case '}':
+            case '$':
+            case '+':
+            case '=':
+            case '^':
+            case '`':
+            case '|':
+            case '~':
+              return true;
+          }
+          break;
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make an Mail-Parameters from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="parameters">The mail parameters that were made.</param>
+    /// <returns>true if the mail parameters can be made, false if not.</returns>
+    /// <remarks><![CDATA[esmtp-param *(SP esmtp-param)]]></remarks>
+    public bool TryMakeMailParameters(ref TokenReader reader, out IReadOnlyDictionary<string, string> parameters)
+    {
+      Dictionary<string, string> dictionary = null;
+
+      while (reader.Peek().Kind != TokenKind.None)
+      {
+        if (reader.TryMake(TryMakeEsmtpParameter, out ReadOnlySequence<byte> keyword, out ReadOnlySequence<byte> value) == false)
+        {
+          parameters = null;
+          return false;
+        }
+
+        dictionary ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        dictionary.Add(StringUtil.Create(keyword), StringUtil.Create(value));
+
+        reader.Skip(TokenKind.Space);
+      }
+
+      parameters = dictionary;
+      return parameters?.Count > 0;
+    }
+
+    /// <summary>
+    /// Try to make an Esmtp-Parameter from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <param name="keyword">The keyword that was made.</param>
+    /// <param name="value">The value that was made.</param>
+    /// <returns>true if the esmtp-parameter can be made, false if not.</returns>
+    /// <remarks><![CDATA[esmtp-keyword ["=" esmtp-value]]]></remarks>
+    public bool TryMakeEsmtpParameter(ref TokenReader reader, out ReadOnlySequence<byte> keyword, out ReadOnlySequence<byte> value)
+    {
+      value = default;
+
+      if (reader.TryMake(TryMakeEsmtpKeyword, out keyword) == false)
+      {
+        return false;
+      }
+
+      if (reader.Peek().Kind == TokenKind.None || reader.Peek().Kind == TokenKind.Space)
+      {
+        return true;
+      }
+
+      if (reader.Take().Kind != TokenKind.Equal)
+      {
+        return false;
+      }
+
+      return reader.TryMake(TryMakeEsmtpValue, out value);
+    }
+
+    /// <summary>
+    /// Try to make an Esmtp-Keyword from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the esmtp-keyword can be made, false if not.</returns>
+    /// <remarks><![CDATA[(ALPHA / DIGIT) *(ALPHA / DIGIT / "-")]]></remarks>
+    public bool TryMakeEsmtpKeyword(ref TokenReader reader)
+    {
+      var token = reader.Take();
+      if (token.Kind != TokenKind.Text && token.Kind != TokenKind.Number)
+      {
+        return false;
+      }
+
+      token = reader.Peek();
+      while (token.Kind == TokenKind.Text || token.Kind == TokenKind.Number || token.Kind == TokenKind.Hyphen)
+      {
+        reader.Take();
+        token = reader.Peek();
+      }
+
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make an Esmtp-Value from the tokens.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the esmtp-value can be made, false if not.</returns>
+    /// <remarks><![CDATA[1*(%d33-60 / %d62-127)]]></remarks>
+    public bool TryMakeEsmtpValue(ref TokenReader reader)
+    {
+      var token = reader.Take();
+      if (token.Kind == TokenKind.None || IsValid(ref token) == false)
+      {
+        return false;
+      }
+
+      token = reader.Peek();
+      while (token.Kind != TokenKind.None && IsValid(ref token))
+      {
+        reader.Take();
+
+        token = reader.Peek();
+      }
+
+      return true;
+
+      static bool IsValid(ref Token token)
+      {
+        var span = token.Text;
+
+        for (var i = 0; i < span.Length; i++)
+        {
+          if ((span[i] < 33 || span[i] > 60) && (span[i] < 62 || span[i] > 127))
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+    }
+
+    /// <summary>
+    /// Try to make a base64 encoded string.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the base64 encoded string can be made, false if not.</returns>
+    /// <remarks><![CDATA[ALPHA / DIGIT / "+" / "/"]]></remarks>
+    public bool TryMakeBase64(ref TokenReader reader)
+    {
+      if (TryMakeBase64Text(ref reader) == false)
+      {
+        return false;
+      }
+
+      if (reader.Peek().Kind == TokenKind.Equal)
+      {
+        reader.Take();
+      }
+
+      if (reader.Peek().Kind == TokenKind.Equal)
+      {
+        reader.Take();
+      }
+
+      return true;
+    }
+
+    /// <summary>
+    /// Try to make a base64 encoded string.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the base64 encoded string can be made, false if not.</returns>
+    /// <remarks><![CDATA[ALPHA / DIGIT / "+" / "/"]]></remarks>
+    public bool TryMakeBase64Text(ref TokenReader reader)
+    {
+      var count = 0;
+
+      while (reader.TryMake(TryMakeBase64Chars))
+      {
+        count++;
+      }
+
+      return count > 0;
+    }
+
+    /// <summary>
+    /// Try to make the allowable characters in a base64 encoded string.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if the base64-chars can be made, false if not.</returns>
+    /// <remarks><![CDATA[ALPHA / DIGIT / "+" / "/"]]></remarks>
+    public bool TryMakeBase64Chars(ref TokenReader reader)
+    {
+      var token = reader.Take();
+
+      switch (token.Kind)
+      {
+        case TokenKind.Text:
+        case TokenKind.Number:
+        case TokenKind.Slash:
+        case TokenKind.Plus:
+          return true;
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make a text sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if a text sequence could be made, false if not.</returns>
+    public bool TryMakeText(ref TokenReader reader)
+    {
+      if (reader.Peek().Kind == TokenKind.Text)
+      {
+        reader.Skip(TokenKind.Text);
+        return true;
+      }
+
+      return false;
+    }
+
+    /// <summary>
+    /// Try to make a number sequence.
+    /// </summary>
+    /// <param name="reader">The reader to perform the operation on.</param>
+    /// <returns>true if a number sequence could be made, false if not.</returns>
+    public bool TryMakeNumber(ref TokenReader reader)
+    {
+      if (reader.Peek().Kind == TokenKind.Number)
+      {
+        reader.Skip(TokenKind.Number);
+        return true;
+      }
+
+      return false;
+    }
+
+    public bool TryMakeSomethingText(ref TokenReader reader)
+    {
+      var count = 0;
+
+      while (reader.TryMake(TryMakeSomethingChars))
+      {
+        count++;
+      }
+
+      return count > 0;
+    }
+
+    public bool TryMakeSomethingChars(ref TokenReader reader)
+    {
+      var token = reader.Take();
+
+      switch (token.Kind)
+      {
+        case TokenKind.Text:
+        case TokenKind.Number:
+        case TokenKind.Space:
+        case TokenKind.Hyphen:
+        case TokenKind.Period:
+        case TokenKind.LeftBracket:
+        case TokenKind.RightBracket:
+        case TokenKind.Colon:
+        case TokenKind.GreaterThan:
+        case TokenKind.LessThan:
+        case TokenKind.Comma:
+        case TokenKind.At:
+        case TokenKind.Quote:
+        case TokenKind.Equal:
+        case TokenKind.Slash:
+        case TokenKind.Backslash:
+        case TokenKind.Plus:
+          return true;
+      }
+
+      return false;
+    }
   }
 }

--- a/src/Pop3Server/Protocol/TopCommand.cs
+++ b/src/Pop3Server/Protocol/TopCommand.cs
@@ -8,29 +8,6 @@ using Pop3Server.Storage;
 
 namespace Pop3Server.Protocol
 {
-  public static class ASCII
-  {
-    /// <summary>
-    /// Carriage return (CR)
-    /// </summary>
-    public const byte CR = 13;
-
-    /// <summary>
-    /// Line feed (LF)
-    /// </summary>
-    public const byte LF = 10;
-
-    /// <summary>
-    /// dot (.)
-    /// </summary>
-    public const byte Dot = 46;
-
-    public static readonly byte[] DotArray = new byte[] { ASCII.Dot };
-    public static readonly byte[] CrLfArray = new byte[] { ASCII.CR, ASCII.LF };
-    public const string NewLine = "\r\n";
-    public const int NewLineLength = 2;
-  }
-
   public sealed class TopCommand : SmtpCommand
   {
     public const string Command = "TOP";
@@ -115,7 +92,7 @@ namespace Pop3Server.Protocol
         {
           inBody = true;
 
-          // Diese Zeile MUSS IMMER geschrieben werden (RFC-konform)
+          // This line MUST ALWAYS be written (RFC-compliant)
           if (line.StartsWith(ASCII.DotArray))
             context.Pipe.Output.Write(ASCII.DotArray);
 

--- a/src/Pop3Server/Protocol/TopCommand.cs
+++ b/src/Pop3Server/Protocol/TopCommand.cs
@@ -1,37 +1,169 @@
+using System;
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
+using Pop3Server.ComponentModel;
 using Pop3Server.IO;
+using Pop3Server.Storage;
 
 namespace Pop3Server.Protocol
 {
-    public sealed class TopCommand : SmtpCommand
+  public static class ASCII
+  {
+    /// <summary>
+    /// Carriage return (CR)
+    /// </summary>
+    public const byte CR = 13;
+
+    /// <summary>
+    /// Line feed (LF)
+    /// </summary>
+    public const byte LF = 10;
+
+    /// <summary>
+    /// dot (.)
+    /// </summary>
+    public const byte Dot = 46;
+
+    public static readonly byte[] DotArray = new byte[] { ASCII.Dot };
+    public static readonly byte[] CrLfArray = new byte[] { ASCII.CR, ASCII.LF };
+    public const string NewLine = "\r\n";
+    public const int NewLineLength = 2;
+  }
+
+  public sealed class TopCommand : SmtpCommand
+  {
+    public const string Command = "TOP";
+
+    public int Message { get; }
+    public int Lines { get; }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public TopCommand(int message, int lines) : base(Command)
     {
-      public const string Command = "TOP";
-
-      public int Message { get; }
-      public int Lines { get; }
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        public TopCommand(int message, int lines) : base(Command)
-        {
-          Message = message;
-          Lines = lines;
-        }
-
-        /// <summary>
-        /// Execute the command.
-        /// </summary>
-        /// <param name="context">The execution context to operate on.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>Returns true if the command executed successfully such that the transition to the next state should occurr, false 
-        /// if the current state is to be maintained.</returns>
-        internal override async Task<bool> ExecuteAsync(SmtpSessionContext context, CancellationToken cancellationToken)
-        {
-            await context.Pipe.Output.WriteReplyAsync(SmtpResponse.Ok, cancellationToken).ConfigureAwait(false);
-
-            return true;
-        }
+      Message = message;
+      Lines = lines;
     }
+
+    /// <summary>
+    /// Execute the command.
+    /// </summary>
+    /// <param name="context">The execution context to operate on.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Returns true if the command executed successfully such that the transition to the next state should occurr, false
+    /// if the current state is to be maintained.</returns>
+    internal override async Task<bool> ExecuteAsync(SmtpSessionContext context, CancellationToken cancellationToken)
+    {
+      var messageStore = context.ServiceProvider.GetService<IMessageStoreFactory, IMessageStore>(context, MessageStore.Default);
+      using var messageStoreContainer = new DisposableContainer<IMessageStore>(messageStore);
+
+      if (Message < 1)
+        goto noSuchMessage;
+      if (Message > context.Transaction.Messages.Count)
+        goto noSuchMessage;
+
+      var message = context.Transaction.Messages[Message - 1];
+      if (message == null || message.DeleteRequested)
+        goto noSuchMessage;
+
+      var bytes = await messageStoreContainer.Instance.GetAsync(context, context.Transaction.Mailbox, message, cancellationToken).ConfigureAwait(false);
+
+      await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Ok, "message follows"), cancellationToken).ConfigureAwait(false);
+
+      WriteDotStuffedWithLineLimit(context, bytes, Lines);
+
+      context.Pipe.Output.Write(ASCII.DotArray);
+      context.Pipe.Output.Write(ASCII.CrLfArray);
+
+      await context.Pipe.Output.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+      return true;
+
+    // -ERR no such message
+    noSuchMessage:
+      await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.Err, "no such message"), cancellationToken).ConfigureAwait(false);
+      return false;
+    }
+
+    /// <summary>
+    /// Writes email content with dot-stuffing (RFC 1939) and enforces a line limit for the body portion.
+    /// Dot-stuffing adds an extra dot at the beginning of lines that start with a dot to prevent
+    /// premature message termination.
+    /// </summary>
+    /// <param name="context">The SMTP session context containing the output pipe.</param>
+    /// <param name="data">The raw email message data to process.</param>
+    /// <param name="maxLines">Maximum number of body lines to write (headers are always written in full).</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>True if the output ends with CRLF, false otherwise.</returns>
+    private void WriteDotStuffedWithLineLimit(SmtpSessionContext context, byte[] data, int maxLines)
+    {
+      var remaining = new ReadOnlySpan<byte>(data);
+      var linesWritten = 0;
+      var inBody = false;
+
+      // Process the message line by line
+      var index = remaining.IndexOfNewLine();
+      while (index >= 0)
+      {
+        // Extract current line including CRLF (index points to CR, +2 includes CRLF)
+        var line = remaining.Slice(0, index + ASCII.NewLineLength);
+
+        // Detect transition from headers to body (empty line = only newline characters)
+        if (!inBody && line.Length == ASCII.NewLineLength)
+        {
+          inBody = true;
+
+          // Diese Zeile MUSS IMMER geschrieben werden (RFC-konform)
+          if (line.StartsWith(ASCII.DotArray))
+            context.Pipe.Output.Write(ASCII.DotArray);
+
+          context.Pipe.Output.Write(line);
+        }
+        else if (inBody)
+        {
+          // Stop writing body lines once we've reached the limit
+          if (linesWritten >= maxLines)
+            break;
+
+          // Apply dot-stuffing if line starts with a dot
+          if (line.StartsWith(ASCII.DotArray))
+            context.Pipe.Output.Write(ASCII.DotArray);
+
+          context.Pipe.Output.Write(line);
+          linesWritten++;
+        }
+        else
+        {
+          // Write all header lines without counting toward the line limit
+          if (line.StartsWith(ASCII.DotArray))
+            context.Pipe.Output.Write(ASCII.DotArray);
+
+          context.Pipe.Output.Write(line);
+        }
+
+        // Move to the next line
+        remaining = remaining.Slice(index + ASCII.NewLineLength);
+        index = remaining.IndexOfNewLine();
+      }
+
+      // Handle any remaining bytes (last line without CRLF or partial data)
+      if (remaining.Length > 0)
+      {
+        // Only write remaining data if:
+        // - We're still in headers, OR
+        // - We're in body but haven't exceeded the line limit
+        if (!inBody || linesWritten < maxLines)
+        {
+          // Apply dot-stuffing if remaining data starts with a dot
+          if (remaining.StartsWith(ASCII.DotArray))
+            context.Pipe.Output.Write(ASCII.DotArray);
+
+          context.Pipe.Output.Write(remaining);
+          context.Pipe.Output.Write(ASCII.CrLfArray);
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Introduced `TopCommand` to handle the `TOP` POP3 command, including support for returning headers and limited body lines with dot-stuffing. Refactored `RetrCommand` for improved readability, error handling, and compliance with POP3 standards. Fixing some bugs in `RetrCommand`.

Added a new `Pop3Server.Test` project targeting `.NET 9.0` with `xUnit` for unit testing. Implemented comprehensive tests for `RetrCommand` and `TopCommand`, covering edge cases like multipart MIME messages and dot-stuffing.

Created test helpers (`TestMessageStore`, `TestServiceProvider`, etc.) to facilitate mocking and dependency injection. Added `SpanExtensions` for `ReadOnlySpan<byte>` operations and an `ASCII` utility class for common constants.

Refactored `SmtpParser` for better maintainability and added XML documentation. Improved code formatting and consistency across the project.